### PR TITLE
Allows caller to specify port for Bypass

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -4,8 +4,8 @@ defmodule Bypass do
   import Bypass.Utils
   require Logger
 
-  def open do
-    {:ok, pid, port} = Supervisor.start_child(Bypass.Supervisor, [])
+  def open(opts \\ []) do
+    {:ok, pid, port} = Supervisor.start_child(Bypass.Supervisor, [opts])
 
     debug_log "Did open connection #{inspect pid} on port #{inspect port}"
     ExUnit.Callbacks.on_exit({Bypass, pid}, fn ->

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -14,7 +14,6 @@ defmodule BypassTest do
     end
   end
 
-
   test "Bypass.expect's fun gets called for every single request" do
     bypass = Bypass.open
     parent = self()
@@ -26,6 +25,17 @@ defmodule BypassTest do
       assert {:ok, 200, ""} = request(bypass.port)
       assert_receive :request_received
     end)
+  end
+
+  test "Bypass.open can specify a port to operate on" do
+    port = 1234
+    bypass = Bypass.open(port: port)
+
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.send_resp(conn, 200, "")
+    end)
+
+    assert {:ok, 200, ""} = request(port)
   end
 
   test "Bypass.down takes down the socket" do


### PR DESCRIPTION
RE: https://github.com/PSPDFKit-labs/bypass/issues/25

This PR allows a caller to specify a port at which to open a new Bypass instance.

Not sure if you guys are open to PRs, but I have this running locally and wanted to share as others may encounter similar problems as me.

This is implemented as a keyword list options argument to `Bypass.open` under the assumption that the keys passed may grow as the library continues to mature.