### PR TITLE
Adding concurrent request capabilities as well as named routing (new)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: elixir
 elixir:
-  - 1.0.5
-  - 1.1.1
-  - 1.2.5
-  - 1.3.2
-  - 1.4.1
+  - 1.3.4
+  - 1.4.5
 otp_release:
   - 18.3
-  - 19.0
+  - 19.3
+  - 20.0
 sudo: false # to use faster container based build environment
 env:
   - MIX_ENV=test
@@ -19,9 +17,5 @@ script:
   - mix test
 matrix:
   exclude:
-    - otp_release: 19.0
-      elixir: 1.0.5
-    - otp_release: 19.0
-      elixir: 1.1.1
-    - otp_release: 19.0
-      elixir: 1.2.5
+    - otp_release: 20.0
+      elixir: 1.3.4

--- a/README.md
+++ b/README.md
@@ -38,6 +38,72 @@ If you want to test what happens when the HTTP server goes down, use `Bypass.dow
 TCP socket and `Bypass.up/1` to start listening on the same port again. Both functions block until
 the socket updates its state.
 
+### Expect Functions
+
+You can take any of the following approaches:
+* `expect/2` or `expect_once/2` to install a generic function that all calls to bypass will use
+* `expect/4` and/or `expect_once/4` to install specific routes (method, path combinations)
+* a combination of the above, where the routes will be used first, and then the generic version
+  will be used as default
+
+#### expect/2 (bypass_instance, function)
+
+Must be called at least once, and it will error if not.  As an alternative, `nil` can be passed
+in place of a function to indicate that it should never be called (and it will error if it is).
+
+```elixir
+  Bypass.expect bypass, fn conn ->
+    assert "/1.1/statuses/update.json" == conn.request_path
+    assert "POST" == conn.method
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end
+```
+
+#### expect_once/2 (bypass_instance, function)
+
+Must be called exactly once, and it will error if not. As an alternative, `nil` can be passed
+in place of a function to indicate that it should never be called (and it will error if it is)
+
+```elixir
+  Bypass.expect_once bypass, fn conn ->
+    assert "/1.1/statuses/update.json" == conn.request_path
+    assert "POST" == conn.method
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end
+```
+
+#### expect/4 (bypass_instance, method | [method1, method2...], path | [path1, path2...], function)
+
+Must be called at least once, and it will error if not.  As an alternative, `nil` can be passed
+in place of a function to indicate that it should never be called (and it will error if it is).
+
+The methods can be passed as a binary or a `List` of binaries, and the paths can also be passed in
+that way.  All combinations will be required to be called.
+
+```elixir
+  Bypass.expect bypass, "POST", "/1.1/statuses/update.json", fn conn ->
+    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no+1} end)
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end
+```
+
+#### expect_once/4 (bypass_instance, method | [method1, method2...], path | [path1, path2...], function)
+
+Must be called exactly once, and it will error if not. As an alternative, `nil` can be passed
+in place of a function to indicate that it should never be called (and it will error if it is).
+
+The methods can be passed as a binary or a `List` of binaries, and the paths can also be passed in
+that way.  All combinations will be required to be called.
+
+```elixir
+  Bypass.expect_once bypass, "POST", "/1.1/statuses/update.json", fn conn ->
+    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no+1} end)
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end
+```
+
+### Example
+
 In the following example `TwitterClient.start_link()` takes the endpoint URL as its argument
 allowing us to make sure it will connect to the running instance of Bypass.
 
@@ -51,11 +117,10 @@ defmodule TwitterClientTest do
   end
 
   test "client can handle an error response", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      assert "/1.1/statuses/update.json" == conn.request_path
-      assert "POST" == conn.method
+    Bypass.expect_once bypass, "POST", "/1.1/statuses/update.json", fn conn ->
       Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
     end
+    Bypass.expect bypass, nil # ensure that no other API endpoints are called
     {:ok, client} = TwitterClient.start_link(url: endpoint_url(bypass.port))
     assert {:error, :rate_limited} == TwitterClient.post_tweet(client, "Elixir is awesome!")
   end
@@ -90,7 +155,8 @@ end
 That's all you need to do. Bypass automatically sets up an `on_exit` hook to close its socket when
 the test finishes running.
 
-Multiple concurrent Bypass instances are supported, all will have a different unique port.
+Multiple concurrent Bypass instances are supported, all will have a different unique port.  Concurrent
+requests are also supported on the same instance.
 
 In case you need to assign a specific port to a Bypass instance to listen on, you can pass the
 `port` option to `Bypass.open()`:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the socket updates its state.
 
 You can take any of the following approaches:
 * `expect/2` or `expect_once/2` to install a generic function that all calls to bypass will use
-* `expect/4` and/or `expect_once/4` to install specific routes (method, path combinations)
+* `expect/4` and/or `expect_once/4` to install specific routes (method and path)
 * a combination of the above, where the routes will be used first, and then the generic version
   will be used as default
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ You can take any of the following approaches:
 
 #### expect/2 (bypass_instance, function)
 
-Must be called at least once, and it will error if not.  As an alternative, `nil` can be passed
-in place of a function to indicate that it should never be called (and it will error if it is).
+Must be called at least once.
 
 ```elixir
   Bypass.expect bypass, fn conn ->
@@ -61,8 +60,7 @@ in place of a function to indicate that it should never be called (and it will e
 
 #### expect_once/2 (bypass_instance, function)
 
-Must be called exactly once, and it will error if not. As an alternative, `nil` can be passed
-in place of a function to indicate that it should never be called (and it will error if it is)
+Must be called exactly once.
 
 ```elixir
   Bypass.expect_once bypass, fn conn ->
@@ -72,13 +70,13 @@ in place of a function to indicate that it should never be called (and it will e
   end
 ```
 
-#### expect/4 (bypass_instance, method | [method1, method2...], path | [path1, path2...], function)
+#### expect/4 (bypass_instance, method, path, function)
 
-Must be called at least once, and it will error if not.  As an alternative, `nil` can be passed
-in place of a function to indicate that it should never be called (and it will error if it is).
+Must be called at least once.
 
-The methods can be passed as a binary or a `List` of binaries, and the paths can also be passed in
-that way.  All combinations will be required to be called.
+`method` is one of `["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "CONNECT"]`
+
+`path` is the endpoint.
 
 ```elixir
   Bypass.expect bypass, "POST", "/1.1/statuses/update.json", fn conn ->
@@ -87,13 +85,13 @@ that way.  All combinations will be required to be called.
   end
 ```
 
-#### expect_once/4 (bypass_instance, method | [method1, method2...], path | [path1, path2...], function)
+#### expect_once/4 (bypass_instance, method, path, function)
 
-Must be called exactly once, and it will error if not. As an alternative, `nil` can be passed
-in place of a function to indicate that it should never be called (and it will error if it is).
+Must be called exactly once.
 
-The methods can be passed as a binary or a `List` of binaries, and the paths can also be passed in
-that way.  All combinations will be required to be called.
+`method` is one of `["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "CONNECT"]`
+
+`path` is the endpoint.
 
 ```elixir
   Bypass.expect_once bypass, "POST", "/1.1/statuses/update.json", fn conn ->
@@ -120,7 +118,6 @@ defmodule TwitterClientTest do
     Bypass.expect_once bypass, "POST", "/1.1/statuses/update.json", fn conn ->
       Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
     end
-    Bypass.expect bypass, nil # ensure that no other API endpoints are called
     {:ok, client} = TwitterClient.start_link(url: endpoint_url(bypass.port))
     assert {:error, :rate_limited} == TwitterClient.post_tweet(client, "Elixir is awesome!")
   end

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -17,6 +17,8 @@ defmodule Bypass do
               :ok
             {:error, :unexpected_count, errors} ->
               raise ExUnit.AssertionError, errors
+            {:error, :disallowed_expect} ->
+              raise ExUnit.AssertionError, "Passed expect function is not a function"
             {:exit, {class, reason, stacktrace}} ->
               :erlang.raise(class, reason, stacktrace)
           end

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -15,10 +15,8 @@ defmodule Bypass do
               :ok
             :ok_call ->
               :ok
-            {:error, :not_called} ->
-              raise ExUnit.AssertionError, "No HTTP request arrived at Bypass"
-            {:error, :unexpected_request} ->
-              raise ExUnit.AssertionError, "Bypass got an HTTP request but wasn't expecting one"
+            {:error, :unexpected_count, errors} ->
+              raise ExUnit.AssertionError, errors
             {:exit, {class, reason, stacktrace}} ->
               :erlang.raise(class, reason, stacktrace)
           end
@@ -38,7 +36,16 @@ defmodule Bypass do
   def expect(%Bypass{pid: pid}, fun),
     do: Bypass.Instance.call(pid, {:expect, fun})
 
+  def expect(%Bypass{pid: pid}, methods, paths, fun),
+    do: Bypass.Instance.call(pid, {:expect, methods, paths, fun})
+
+  def expect_once(%Bypass{pid: pid}, fun),
+    do: Bypass.Instance.call(pid, {:expect_once, fun})
+
+  def expect_once(%Bypass{pid: pid}, methods, paths, fun),
+    do: Bypass.Instance.call(pid, {:expect_once, methods, paths, fun})
+
   def pass(%Bypass{pid: pid}),
-    do: Bypass.Instance.call(pid, {:put_expect_result, :ok})
+    do: Bypass.Instance.call(pid, :pass)
 
 end

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -15,10 +15,20 @@ defmodule Bypass do
               :ok
             :ok_call ->
               :ok
-            {:error, :unexpected_count, errors} ->
-              raise ExUnit.AssertionError, errors
-            {:error, :disallowed_expect} ->
-              raise ExUnit.AssertionError, "Passed expect function is not a function"
+            {:error, :too_many_requests, {:any, :any}} ->
+              raise ExUnit.AssertionError, "Expected only one HTTP request for Bypass"
+            {:error, :too_many_requests, {method, path}} ->
+              raise ExUnit.AssertionError, "Expected only one HTTP request for Bypass at #{method} #{path}"
+            {:error, :unexpected_request, {:any, :any}} ->
+              raise ExUnit.AssertionError, "Bypass got an HTTP request but wasn't expecting one"
+            {:error, :unexpected_request, {method, path}} ->
+              raise ExUnit.AssertionError,
+                "Bypass got an HTTP request but wasn't expecting one at #{method} #{path}"
+            {:error, :not_called, {:any, :any}} ->
+              raise ExUnit.AssertionError, "No HTTP request arrived at Bypass"
+            {:error, :not_called, {method, path}} ->
+              raise ExUnit.AssertionError,
+                "No HTTP request arrived at Bypass at #{method} #{path}"
             {:exit, {class, reason, stacktrace}} ->
               :erlang.raise(class, reason, stacktrace)
           end

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -167,11 +167,6 @@ defmodule Bypass.Instance do
     end
   end
 
-  defp increase_route_count(state, route) do
-    update_in(state[:expectations][route],
-      fn route_expectations -> Map.update(route_expectations, :request_count, 1, &(&1 + 1)) end)
-  end
-
   defp do_handle_call({:put_expect_result, route, ref, result}, _from, state) do
     updated_state =
       put_result(route, ref, result, state)
@@ -198,7 +193,7 @@ defmodule Bypass.Instance do
           %{state | socket: nil}
       end
 
-    result = 
+    result =
       cond do
         state.pass ->
           :ok
@@ -226,6 +221,11 @@ defmodule Bypass.Instance do
              })
            end)
     end
+  end
+
+  defp increase_route_count(state, route) do
+    update_in(state[:expectations][route],
+      fn route_expectations -> Map.update(route_expectations, :request_count, 1, &(&1 + 1)) end)
   end
 
   defp expectation_problem_message(expectations) do
@@ -293,7 +293,7 @@ defmodule Bypass.Instance do
         end
 
       if length(exit_callers) > 0 do
-        {result, updated_state} = do_exit(state)
+        {result, _updated_state} = do_exit(state)
         Enum.each(exit_callers, &(GenServer.reply(&1, result)))
         GenServer.stop(:normal)
       end

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -160,7 +160,7 @@ defmodule Bypass.Instance do
   end
 
   defp do_handle_call(
-    {:get_expect_fun, {method, path} = route}, _from, %{expectations: expectations} = state
+    {:get_expect_fun, route}, _from, %{expectations: expectations} = state
   ) do
     case Map.get(expectations, route) do
       %{expected: :once, request_count: count} when count > 0 ->
@@ -236,14 +236,14 @@ defmodule Bypass.Instance do
   defp expectation_problem_message(expectations) do
     problem_route =
       expectations
-      |> Enum.find(fn {route, expectations} -> length(expectations.results) == 0 end)
+      |> Enum.find(fn {_route, expectations} -> length(expectations.results) == 0 end)
 
     case problem_route do
       {route, _} -> {:error, :no_request, route}
-      nil -> Enum.reduce_while(expectations, nil, fn {route, route_expectations}, _ ->
+      nil -> Enum.reduce_while(expectations, nil, fn {_route, route_expectations}, _ ->
                first_error = Enum.find(route_expectations.results, fn
                  result when is_tuple(result) -> result
-                 result -> nil
+                 _result -> nil
                end)
                case first_error do
                  nil -> {:cont, nil}

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -129,12 +129,7 @@ defmodule Bypass.Instance do
           raise "Route already installed for #{method}, #{path}"
       end
 
-    case updated_expectations do
-      {:error, error_name, msg} ->
-        {:reply, {:error, error_name, msg}, state}
-      _ ->
-        {:reply, :ok, %{state | expectations: updated_expectations}}
-    end
+    {:reply, :ok, %{state | expectations: updated_expectations}}
   end
 
   defp do_handle_call({expect, _, _, _}, _from, _state)
@@ -239,7 +234,7 @@ defmodule Bypass.Instance do
       |> Enum.find(fn {_route, expectations} -> length(expectations.results) == 0 end)
 
     case problem_route do
-      {route, _} -> {:error, :no_request, route}
+      {route, _} -> {:error, :not_called, route}
       nil -> Enum.reduce_while(expectations, nil, fn {_route, route_expectations}, _ ->
                first_error = Enum.find(route_expectations.results, fn
                  result when is_tuple(result) -> result

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -137,7 +137,7 @@ defmodule Bypass.Instance do
     end
   end
 
-  defp do_handle_call({expect, _, _, _}, _from, state)
+  defp do_handle_call({expect, _, _, _}, _from, _state)
     when expect in [:expect, :expect_once]
   do
     raise "Route for #{expect} does not conform to specification"

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -19,9 +19,9 @@ defmodule Bypass.Plug do
             put_result(pid, route, ref, {:exit, {class, reason, stacktrace}})
             :erlang.raise(class, reason, stacktrace)
         end
-      nil ->
-        put_result(pid, route, ref, {:error, :unexpected_request})
-        conn
+      {:error, error, route} ->
+        put_result(pid, route, ref, {:error, error, route})
+        raise "Route error"
     end
   end
 

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -1,28 +1,35 @@
 defmodule Bypass.Plug do
   def init([pid]), do: pid
 
-  def call(conn, pid) do
-    case Bypass.Instance.call(pid, :get_expect_fun) do
+  def call(%{method: method, request_path: request_path} = conn, pid) do
+    route = Bypass.Instance.call(pid, {:get_route, method, request_path})
+    ref = make_ref()
+    case Bypass.Instance.call(pid, {:get_expect_fun, route}) do
       fun when is_function(fun, 1) ->
-        retain_current_plug(pid)
+        retain_current_plug(pid, route, ref)
         try do
           fun.(conn)
         else
           conn ->
-            put_result(pid, :ok_call)
+            put_result(pid, route, ref, :ok_call)
             conn
         catch
           class, reason ->
             stacktrace = System.stacktrace
-            put_result(pid, {:exit, {class, reason, stacktrace}})
+            put_result(pid, route, ref, {:exit, {class, reason, stacktrace}})
             :erlang.raise(class, reason, stacktrace)
         end
       nil ->
-        put_result(pid, {:error, :unexpected_request})
+        put_result(pid, route, ref, {:error, :unexpected_request})
         conn
     end
   end
 
-  defp retain_current_plug(pid), do: Bypass.Instance.cast(pid, {:retain_plug_process, self()})
-  defp put_result(pid, result), do: Bypass.Instance.call(pid, {:put_expect_result, result})
+  defp retain_current_plug(pid, route, ref) do
+    Bypass.Instance.cast(pid, {:retain_plug_process, route, ref, self()})
+  end
+
+  defp put_result(pid, route, ref, result) do
+    Bypass.Instance.call(pid, {:put_expect_result, route, ref, result})
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
-  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gun": {:git, "https://github.com/PSPDFKit-labs/gun.git", "0462585ec7b0bcb2ca4b8b91e6d2624a45324b6e", []},
-  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}
+  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], [], "hexpm"}}

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -279,27 +279,6 @@ defmodule BypassTest do
     end)
   end
 
-  defp concurrent_requests(expect_fun) do
-    bypass = Bypass.open
-    parent = self()
-
-    apply(Bypass, expect_fun, [
-      bypass,
-      fn conn ->
-        send(parent, :request_received)
-        Plug.Conn.send_resp(conn, 200, "")
-      end
-    ])
-    tasks = Enum.map(1..5, fn _ ->
-      Task.async(fn -> {:ok, 200, ""} = request(bypass.port) end)
-    end)
-    Enum.map(tasks, fn task ->
-      Task.await(task)
-      assert_receive :request_received
-    end)
-    bypass
-  end
-
   test "Bypass.expect/4 can be used to define a specific route" do
     :expect |> specific_route
   end

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -130,11 +130,13 @@ defmodule BypassTest do
     end)
   end
 
-  test "Bypass.expect can be canceled by expecting nil" do
+  # no longer allowing `nil`s as an override for a previously
+  # passed expect/handler function
+  test "passing Bypass.expect a nil raises an error" do
     :expect |> cancel
   end
 
-  test "Bypass.expect_once can be canceled by expecting nil" do
+  test "passing Bypass.expect_once a nil raises an error" do
     :expect_once |> cancel
   end
 
@@ -147,6 +149,12 @@ defmodule BypassTest do
       fn _conn -> assert false end
     ])
     Bypass.expect(bypass, nil)
+
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :disallowed_expect} == exit_result
+    end)
   end
 
   test "Bypass.expect can be made to pass by calling Bypass.pass" do

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -15,11 +15,7 @@ defmodule BypassTest do
   end
 
   test "Bypass.expect's fun gets called for every single request" do
-    bypass = five_requests(:expect)
-    # Override Bypass' on_exit handler
-    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
-      :ok == Bypass.Instance.call(bypass.pid, :on_exit)
-    end)
+    five_requests(:expect)
   end
 
   test "Bypass.expect_once's fun gets called for each request, with an error reported for too many calls" do

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -75,14 +75,14 @@ defmodule BypassTest do
   end
 
   test "Bypass.expect raises if no request is made" do
-    :expect |> no_request
+    :expect |> not_called
   end
 
   test "Bypass.expect_once raises if no request is made" do
-    :expect_once |> no_request
+    :expect_once |> not_called
   end
 
-  defp no_request(expect_fun) do
+  defp not_called(expect_fun) do
     bypass = Bypass.open
 
     # one of Bypass.expect or Bypass.expect_once
@@ -93,7 +93,7 @@ defmodule BypassTest do
     # Override Bypass' on_exit handler
     ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
       exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
-      assert {:error, :no_request, {:any, :any}} = exit_result
+      assert {:error, :not_called, {:any, :any}} = exit_result
     end)
   end
 
@@ -221,6 +221,7 @@ defmodule BypassTest do
     end)
   end
 
+  @tag :wip
   test "Calling a bypass route without expecting a call fails the test" do
     bypass = Bypass.open
     capture_log fn ->
@@ -337,7 +338,7 @@ defmodule BypassTest do
     # Override Bypass' on_exit handler
     ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
       exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
-      assert {:error, :no_request, {"POST", "/that"}} = exit_result
+      assert {:error, :not_called, {"POST", "/that"}} = exit_result
     end)
   end
 

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -15,37 +15,81 @@ defmodule BypassTest do
   end
 
   test "Bypass.expect's fun gets called for every single request" do
+    bypass = five_requests(:expect)
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      :ok == Bypass.Instance.call(bypass.pid, :on_exit)
+    end)
+  end
+
+  test "Bypass.expect_once's fun gets called for each request, with an error reported for too many calls" do
+    bypass = five_requests(:expect_once)
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :unexpected_count, _} = exit_result
+      assert Regex.match?(~r/passed function.+called 5 times/, elem(exit_result, 2))
+    end)
+  end
+
+  defp five_requests(expect_fun) do
     bypass = Bypass.open
     parent = self()
-    Bypass.expect(bypass, fn conn ->
-      send(parent, :request_received)
-      Plug.Conn.send_resp(conn, 200, "")
-    end)
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn conn ->
+        send(parent, :request_received)
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
     Enum.each(1..5, fn _ ->
       assert {:ok, 200, ""} = request(bypass.port)
       assert_receive :request_received
     end)
+    bypass
   end
 
-  test "Bypass.open can specify a port to operate on" do
-    port = 1234
+  test "Bypass.open can specify a port to operate on with expect" do
+    1234 |> specify_port(:expect)
+  end
+
+  test "Bypass.open can specify a port to operate on with expect_once" do
+    1235 |> specify_port(:expect_once)
+  end
+
+  defp specify_port(port, expect_fun) do
     bypass = Bypass.open(port: port)
-
-    Bypass.expect(bypass, fn conn ->
-      assert port == conn.port
-      Plug.Conn.send_resp(conn, 200, "")
-    end)
-
+  
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn conn ->
+        assert port == conn.port
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+  
     assert {:ok, 200, ""} = request(port)
-
     assert {:error, :eaddrinuse} == Bypass.open(port: port)
   end
 
-  test "Bypass.down takes down the socket" do
+  test "Bypass.down takes down the socket with expect" do
+    :expect |> down_socket
+  end
+
+  test "Bypass.down takes down the socket with expect_once" do
+    :expect_once |> down_socket
+  end
+
+  defp down_socket(expect_fun) do
     bypass = Bypass.open
-    Bypass.expect(bypass, fn conn ->
-      Plug.Conn.send_resp(conn, 200, "")
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn conn -> Plug.Conn.send_resp(conn, 200, "") end
+    ])
     assert {:ok, 200, ""} = request(bypass.port)
 
     Bypass.down(bypass)
@@ -67,69 +111,119 @@ defmodule BypassTest do
   end
 
   test "Bypass.expect raises if no request is made" do
+    :expect |> no_request
+  end
+
+  test "Bypass.expect_once raises if no request is made" do
+    :expect_once |> no_request
+  end
+
+  defp no_request(expect_fun) do
     bypass = Bypass.open
-    Bypass.expect(bypass, fn _conn ->
-      assert false
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn _conn -> assert false end
+    ])
     # Override Bypass' on_exit handler
     ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
-      assert {:error, :not_called} == Bypass.Instance.call(bypass.pid, :on_exit)
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :unexpected_count, _} = exit_result
+      assert Regex.match?(~r/called 0 times/, elem(exit_result, 2))
     end)
   end
 
   test "Bypass.expect can be canceled by expecting nil" do
+    :expect |> cancel
+  end
+
+  test "Bypass.expect_once can be canceled by expecting nil" do
+    :expect_once |> cancel
+  end
+
+  defp cancel(expect_fun) do
     bypass = Bypass.open
-    Bypass.expect(bypass, fn _conn ->
-      assert false
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn _conn -> assert false end
+    ])
     Bypass.expect(bypass, nil)
   end
 
   test "Bypass.expect can be made to pass by calling Bypass.pass" do
+    :expect |> pass
+  end
+
+  test "Bypass.expect_once can be made to pass by calling Bypass.pass" do
+    :expect_once |> pass
+  end
+
+  defp pass(expect_fun) do
     bypass = Bypass.open
-    Bypass.expect(bypass, fn _conn ->
-      Bypass.pass(bypass)
-      Process.exit(self(), :normal)
-      assert false
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn _conn ->
+        Bypass.pass(bypass)
+        Process.exit(self(), :normal)
+        assert false
+      end
+    ])
 
     capture_log fn ->
       assert {:error, {:closed, 'The connection was lost.'}} = request(bypass.port)
     end
   end
 
-  test "Calling a bypass without expecting a call fails the test" do
-    bypass = Bypass.open
-    capture_log fn ->
-      assert {:ok, 500, ""} = request(bypass.port)
-    end
-
-    # Override Bypass' on_exit handler
-    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
-      assert {:error, :unexpected_request} == Bypass.Instance.call(bypass.pid, :on_exit)
-    end)
+  test "closing a bypass while the request is in-flight with expect" do
+    :expect |> closing_in_flight
   end
 
-  test "closing a bypass while the request is in-flight" do
+  test "closing a bypass while the request is in-flight with expect_once" do
+    :expect_once |> closing_in_flight
+  end
+
+  defp closing_in_flight(expect_fun) do
     bypass = Bypass.open
-    Bypass.expect(bypass, fn _conn ->
-      Bypass.pass(bypass) # mark the request as arrived, since we're shutting it down now
-      Bypass.down(bypass)
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn _conn ->
+        Bypass.pass(bypass) # mark the request as arrived, since we're shutting it down now
+        Bypass.down(bypass)
+      end
+    ])
     assert {:error, {:closed, 'The connection was lost.'}} == request(bypass.port)
   end
 
-  test "Bypass.down waits for plug process to terminate before shutting it down" do
+  test "Bypass.down waits for plug process to terminate before shutting it down with expect" do
+    :expect |> down_wait_to_terminate
+  end
+
+  test "Bypass.down waits for plug process to terminate before shutting it down with expect_once" do
+    :expect_once |> down_wait_to_terminate
+  end
+
+  defp down_wait_to_terminate(expect_fun) do
     test_process = self()
     ref = make_ref()
-
     bypass = Bypass.open
-    Bypass.expect(bypass, fn conn ->
-      result = Plug.Conn.send_resp(conn, 200, "")
-      :timer.sleep(200)
-      send(test_process, ref)
-      result
-    end)
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn conn ->
+        result = Plug.Conn.send_resp(conn, 200, "")
+        :timer.sleep(200)
+        send(test_process, ref)
+        result
+      end
+    ])
 
     assert {:ok, 200, ""} = request(bypass.port)
 
@@ -140,17 +234,237 @@ defmodule BypassTest do
     assert_received ^ref
   end
 
+  test "Conrrent calls to down" do
+    test_process = self()
+    ref = make_ref()
+    bypass = Bypass.open
+
+    Bypass.expect(
+      bypass, "POST", "/this",
+      fn conn ->
+        :timer.sleep(200)
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    )
+
+    Bypass.expect(
+      bypass, "POST", "/that", fn conn ->
+        :timer.sleep(200)
+        result = Plug.Conn.send_resp(conn, 200, "")
+        send(test_process, ref)
+        result
+      end
+    )
+
+    assert {:ok, 200, ""} = request(bypass.port, "/this")
+
+    tasks = Enum.map(1..5, fn _ ->
+      Task.async(fn ->
+        assert {:ok, 200, ""} = request(bypass.port, "/that")
+        Bypass.down(bypass)
+      end)
+    end)
+
+    # Here we make sure that Bypass.down waits until the plug process finishes its work
+    # before shutting down
+    refute_received ^ref
+    :timer.sleep(200)
+    Bypass.down(bypass)
+
+    Enum.map(tasks, fn task ->
+      Task.await(task)
+      assert_received ^ref
+    end)
+  end
+
+  test "Calling a bypass route without expecting a call fails the test" do
+    bypass = Bypass.open
+    capture_log fn ->
+      assert {:ok, 500, ""} = request(bypass.port)
+    end
+
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :unexpected_count, _} = exit_result
+      assert Regex.match?(~r/to never be called.+called 1 time/, elem(exit_result, 2))
+    end)
+  end
+
+  test "Bypass can handle concurrent requests with expect" do
+    bypass = concurrent_requests(:expect)
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      :ok == Bypass.Instance.call(bypass.pid, :on_exit)
+    end)
+  end
+
+  test "Bypass can handle concurrent requests with expect_once" do
+    bypass = concurrent_requests(:expect_once)
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :unexpected_count, _} = exit_result
+      assert Regex.match?(~r/passed function.+called 5 times/, elem(exit_result, 2))
+    end)
+  end
+
+  defp concurrent_requests(expect_fun) do
+    bypass = Bypass.open
+    parent = self()
+    apply(Bypass, expect_fun, [
+      bypass,
+      fn conn ->
+        send(parent, :request_received)
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+    tasks = Enum.map(1..5, fn _ ->
+      Task.async(fn -> {:ok, 200, ""} = request(bypass.port) end)
+    end)
+    Enum.map(tasks, fn task ->
+      Task.await(task)
+      assert_receive :request_received
+    end)
+    bypass
+  end
+
+  test "Bypass.expect/4 can be used to define a specific route" do
+    :expect |> specific_route
+  end
+
+  test "Bypass.expect_once/4 can be used to define a specific route" do
+    :expect_once |> specific_route
+  end
+
+  defp specific_route(expect_fun) do
+    bypass = Bypass.open
+    method = "POST"
+    path = "/this"
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass, method, path, fn conn ->
+        assert conn.method == method
+        assert conn.request_path == path
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+
+    capture_log fn ->
+      assert {:ok, 200, ""} = request(bypass.port, path)
+    end
+  end
+
+  test "Bypass.expect/4 can be used to define multiple paths" do
+    :expect |> multiple_paths
+  end
+
+  test "Bypass.expect_once/4 can be used to define multiple paths" do
+    :expect_once |> multiple_paths
+  end
+
+  defp multiple_paths(expect_fun) do
+    bypass = Bypass.open
+    method = "POST"
+    paths = ["/this", "/that"]
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass, method, paths, fn conn ->
+        assert conn.method == method
+        assert Enum.any?(paths, fn path -> conn.request_path == path end)
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+
+    capture_log fn ->
+      Enum.each(paths, fn path ->
+        assert {:ok, 200, ""} = request(bypass.port, path)
+      end)
+    end
+  end
+
+  test "Bypass.expect/4 can be used to define multiple methods" do
+    :expect |> multiple_methods
+  end
+
+  test "Bypass.expect_once/4 can be used to define multiple methods" do
+    :expect_once |> multiple_methods
+  end
+
+  defp multiple_methods(expect_fun) do
+    bypass = Bypass.open
+    methods = ["POST", "GET"]
+    path = "/this"
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass, methods, path, fn conn ->
+        assert Enum.any?(methods, fn method -> conn.method == method end)
+        assert conn.request_path == path
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+
+    capture_log fn ->
+      Enum.each(methods, fn method ->
+        assert {:ok, 200, ""} =
+          request(bypass.port, path, method |> String.downcase |> String.to_atom)
+      end)
+    end
+  end
+
+  test "All routes to a Bypass.expect/4 call must be called" do
+    :expect |> all_routes_must_be_called
+  end
+
+  test "All routes to a Bypass.expect_once/4 call must be called" do
+    :expect_once |> all_routes_must_be_called
+  end
+
+  defp all_routes_must_be_called(expect_fun) do
+    bypass = Bypass.open
+    method = "POST"
+    paths = ["/this", "/that"]
+
+    # one of Bypass.expect or Bypass.expect_once
+    apply(Bypass, expect_fun, [
+      bypass, method, paths, fn conn ->
+        assert conn.method == method
+        assert Enum.any?(paths, fn path -> conn.request_path == path end)
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
+
+    capture_log fn ->
+      assert {:ok, 200, ""} = request(bypass.port, "/this")
+    end
+
+    # Override Bypass' on_exit handler
+    ExUnit.Callbacks.on_exit({Bypass, bypass.pid}, fn ->
+      exit_result = Bypass.Instance.call(bypass.pid, :on_exit)
+      assert {:error, :unexpected_count, _} = exit_result
+      assert Regex.match?(~r/POST.+\/that.+called 0 times/, elem(exit_result, 2))
+    end)
+  end
+
   @doc ~S"""
   Open a new HTTP connection and perform the request. We don't want to use httpc, hackney or another
   "high-level" HTTP client, since they do connection pooling and we will sometimes get a connection
   closed error and not a failed to connect error, when we test Bypass.down
   """
-  def request(port, path \\ "") do
+  def request(port, path \\ "", method \\ :post) do
     {:ok, conn} = :gun.start_link(self(), '127.0.0.1', port, %{retry: 0})
     try do
       case :gun.await_up(conn, 250) do
         {:ok, _protocol} ->
-           stream = :gun.post(conn, path, [], "")
+           stream =
+             case method do
+               :post -> :gun.post(conn, path, [], "")
+               :get  -> :gun.get(conn, path, [])
+             end
+
            case :gun.await(conn, stream, 250) do
              {:response, :fin, status, _headers} -> {:ok, status, ""}
              {:response, :nofin, status, _headers} ->


### PR DESCRIPTION
This PR contains all changes from #36 + the following cleanups:

- convert mix.lock to new format
- removal of warnings
- update of build matrix