### PR TITLE
Loosen the coupling with ExUnit and add support for ESpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+doc/

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ While Bypass primary targets ExUnit, as it's the official Elixir builtin test fr
 
 1. In your Mix config file, you must declare which test framework Bypass is being used with (defaults to `:ex_unit`). This simply disables the automatic integration with some hooks provided by `ExUnit`.
 ```elixir
-config :bypass, framework: :expec
+config :bypass, framework: :espec
 ```
 
 2. In your specs, you must explicitly verify the declared expectations. You can do it in the `finally` block.
@@ -183,7 +183,7 @@ defmodule TwitterClientSpec do
   end
 
   finally do
-    Bypass.verify_expectations(shared.bypass)
+    Bypass.verify_expectations!(shared.bypass)
   end
 
   specify "the client can handle an error response" do

--- a/README.md
+++ b/README.md
@@ -164,7 +164,14 @@ bypass = Bypass.open(port: 1234)
 
 ## How to use with ESpec
 
-While Bypass primary targets ExUnit, as it's the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same, and the only difference is that you must explicitly call the function to verify the expectations in the `finally` block.
+While Bypass primary targets ExUnit, as it's the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same and the are only two differences:
+
+1. In your Mix config file, you must declare which test framework Bypass is being used with (defaults to `:ex_unit`). This simply disables the automatic integration with some hooks provided by `ExUnit`.
+```elixir
+config :bypass, framework: :expec
+```
+
+2. In your specs, you must explicitly verify the declared expectations. You can do it in the `finally` block.
 
 ```elixir
 defmodule TwitterClientSpec do
@@ -176,7 +183,7 @@ defmodule TwitterClientSpec do
   end
 
   finally do
-    Bypass.verify_expectations(:espec, shared.bypass)
+    Bypass.verify_expectations(shared.bypass)
   end
 
   specify "the client can handle an error response" do

--- a/README.md
+++ b/README.md
@@ -162,6 +162,35 @@ In case you need to assign a specific port to a Bypass instance to listen on, yo
 bypass = Bypass.open(port: 1234)
 ```
 
+## How to use with ESpec
+
+While Bypass primary targets ExUnit, as it's the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same, and the only difference is that you must explicitly call the function to verify the expectations in the `finally` block.
+
+```elixir
+defmodule TwitterClientSpec do
+  use ESpec, async: true
+
+  before do
+    bypass = Bypass.open
+    {:shared, bypass: bypass}
+  end
+
+  finally do
+    Bypass.verify_expectations(:espec, shared.bypass)
+  end
+
+  specify "the client can handle an error response" do
+    Bypass.expect_once shared.bypass, "POST", "/1.1/statuses/update.json", fn conn ->
+      Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+    end
+    {:ok, client} = TwitterClient.start_link(url: endpoint_url(shared.bypass.port))
+    assert {:error, :rate_limited} == TwitterClient.post_tweet(client, "Elixir is awesome!")
+  end
+
+  defp endpoint_url(port), do: "http://localhost:#{port}/"
+end
+```
+
 ## Configuration options
 
 Set `:enable_debug_log` to `true` in the application environment to make Bypass log what it's doing:

--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ bypass = Bypass.open(port: 1234)
 
 ## How to use with ESpec
 
-While Bypass primary targets ExUnit, as it's the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same and the are only two differences:
+While Bypass primarily targets ExUnit, the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same and the are only two differences:
 
 1. In your Mix config file, you must declare which test framework Bypass is being used with (defaults to `:ex_unit`). This simply disables the automatic integration with some hooks provided by `ExUnit`.
+
 ```elixir
 config :bypass, framework: :espec
 ```

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ While Bypass primarily targets ExUnit, the official Elixir builtin test framewor
 1. In your Mix config file, you must declare which test framework Bypass is being used with (defaults to `:ex_unit`). This simply disables the automatic integration with some hooks provided by `ExUnit`.
 
 ```elixir
-config :bypass, framework: :espec
+config :bypass, test_framework: :espec
 ```
 
 2. In your specs, you must explicitly verify the declared expectations. You can do it in the `finally` block.

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :bypass, framework: :ex_unit
+
 config :ex_unit, capture_log: true
 
 config :logger, :console,

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :bypass, framework: :ex_unit
+config :bypass, test_framework: :ex_unit
 
 config :ex_unit, capture_log: true
 

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -1,6 +1,6 @@
 defmodule Bypass do
   @moduledoc """
-  Bypass provides a quick way to create a custom plug that can be put
+  Bypass provides a quick way to create a custom Plug that can be put
   in place instead of an actual HTTP server to return prebaked responses
   to client requests.
 
@@ -57,7 +57,7 @@ defmodule Bypass do
   end
 
   defp verify_expectations!(:ex_unit, _bypass) do
-    raise "Not available in ExUnit, as it's det automatically."
+    raise "Not available in ExUnit, as it's configured automatically."
   end  
 
   if Code.ensure_loaded?(ESpec) do

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -33,10 +33,10 @@ defmodule Bypass do
   if Code.ensure_loaded?(ESpec) do
     def verify_expectations(:espec, bypass) do
       do_verify_expectations(bypass.pid, ESpec.AssertionError)
-    end
-  else
-    def verify_expectations(_framework, _bypass), do: nil
+    end    
   end
+
+  def verify_expectations(_framework, _bypass), do: nil
 
 
   defp do_verify_expectations(bypass_pid, error_module) do

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -4,40 +4,66 @@ defmodule Bypass do
   import Bypass.Utils
   require Logger
 
+
   def open(opts \\ []) do
+    open(:ex_unit, opts)
+  end
+
+  def open(framework, opts) do
     case Supervisor.start_child(Bypass.Supervisor, [opts]) do
       {:ok, pid} ->
         port = Bypass.Instance.call(pid, :port)
         debug_log "Did open connection #{inspect pid} on port #{inspect port}"
-        ExUnit.Callbacks.on_exit({Bypass, pid}, fn ->
-          case Bypass.Instance.call(pid, :on_exit) do
-            :ok ->
-              :ok
-            :ok_call ->
-              :ok
-            {:error, :too_many_requests, {:any, :any}} ->
-              raise ExUnit.AssertionError, "Expected only one HTTP request for Bypass"
-            {:error, :too_many_requests, {method, path}} ->
-              raise ExUnit.AssertionError, "Expected only one HTTP request for Bypass at #{method} #{path}"
-            {:error, :unexpected_request, {:any, :any}} ->
-              raise ExUnit.AssertionError, "Bypass got an HTTP request but wasn't expecting one"
-            {:error, :unexpected_request, {method, path}} ->
-              raise ExUnit.AssertionError,
-                "Bypass got an HTTP request but wasn't expecting one at #{method} #{path}"
-            {:error, :not_called, {:any, :any}} ->
-              raise ExUnit.AssertionError, "No HTTP request arrived at Bypass"
-            {:error, :not_called, {method, path}} ->
-              raise ExUnit.AssertionError,
-                "No HTTP request arrived at Bypass at #{method} #{path}"
-            {:exit, {class, reason, stacktrace}} ->
-              :erlang.raise(class, reason, stacktrace)
-          end
-        end)
+        setup_expectations_verifications(framework, pid)
         %Bypass{pid: pid, port: port}
       other ->
         other
     end
   end
+
+  defp setup_expectations_verifications(:ex_unit, pid) do
+    ExUnit.Callbacks.on_exit({Bypass, pid}, fn ->
+      do_verify_expectations(pid, ExUnit.AssertionError)
+    end)
+  end
+
+  defp setup_expectations_verifications(_framework, _pid), do: nil
+
+
+  if Code.ensure_loaded?(ESpec) do
+    def verify_expectations(:espec, bypass) do
+      do_verify_expectations(bypass.pid, ESpec.AssertionError)
+    end
+  else
+    def verify_expectations(_framework, _bypass), do: nil
+  end
+
+
+  defp do_verify_expectations(bypass_pid, error_module) do
+    case Bypass.Instance.call(bypass_pid, :on_exit) do
+      :ok ->
+        :ok
+      :ok_call ->
+        :ok
+      {:error, :too_many_requests, {:any, :any}} ->
+        raise error_module, "Expected only one HTTP request for Bypass"
+      {:error, :too_many_requests, {method, path}} ->
+        raise error_module, "Expected only one HTTP request for Bypass at #{method} #{path}"
+      {:error, :unexpected_request, {:any, :any}} ->
+        raise error_module, "Bypass got an HTTP request but wasn't expecting one"
+      {:error, :unexpected_request, {method, path}} ->
+        raise error_module,
+          "Bypass got an HTTP request but wasn't expecting one at #{method} #{path}"
+      {:error, :not_called, {:any, :any}} ->
+        raise error_module, "No HTTP request arrived at Bypass"
+      {:error, :not_called, {method, path}} ->
+        raise error_module,
+          "No HTTP request arrived at Bypass at #{method} #{path}"
+      {:exit, {class, reason, stacktrace}} ->
+        :erlang.raise(class, reason, stacktrace)
+    end
+  end
+
 
   def up(%Bypass{pid: pid}),
     do: Bypass.Instance.call(pid, :up)

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -116,6 +116,6 @@ defmodule Bypass do
 
 
   defp test_framework do
-    Application.get_env(:bypass, :framework, :ex_unit)
+    Application.get_env(:bypass, :test_framework, :ex_unit)
   end
 end

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -37,7 +37,7 @@ defmodule Bypass do
   #
   defp setup_framework_integration(:ex_unit, bypass = %{pid: pid}) do
     ExUnit.Callbacks.on_exit({Bypass, pid}, fn ->
-      verify_expectations!(:ex_unit, bypass) 
+      do_verify_expectations(bypass.pid, ExUnit.AssertionError)
     end)
   end
 
@@ -57,7 +57,7 @@ defmodule Bypass do
   end
 
   defp verify_expectations!(:ex_unit, bypass) do
-    do_verify_expectations(bypass.pid, ExUnit.AssertionError)
+    raise "Not available in ExUnit, as it's det automatically."
   end  
 
   if Code.ensure_loaded?(ESpec) do

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -56,7 +56,7 @@ defmodule Bypass do
     verify_expectations!(test_framework(), bypass)
   end
 
-  defp verify_expectations!(:ex_unit, bypass) do
+  defp verify_expectations!(:ex_unit, _bypass) do
     raise "Not available in ExUnit, as it's det automatically."
   end  
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Bypass.Mixfile do
       {:cowboy, "~> 1.0",},
       {:plug, "~> 1.0"},
       {:ex_doc, "> 0.0.0", only: :dev},
+      {:espec, "~> 1.4", only: [:dev, :test]},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
+  "espec": {:hex, :espec, "1.4.1", "d453c32835736bb01b68b32b571fb23ad307f019c33952602a17e3a9b6e6e9b0", [:mix], [{:meck, "0.8.4", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gun": {:git, "https://github.com/PSPDFKit-labs/gun.git", "0462585ec7b0bcb2ca4b8b91e6d2624a45324b6e", []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
   "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], [], "hexpm"}}

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -412,7 +412,7 @@ defmodule BypassTest do
 
 
   test "Bypass.verify_expectations! - with ESpec it will check if the expectations are being met" do
-    Mix.Config.persist bypass: [framework: :espec]
+    Mix.Config.persist bypass: [test_framework: :espec]
 
     # Fail: no requests
     bypass = prepare_stubs()
@@ -446,6 +446,6 @@ defmodule BypassTest do
       Bypass.verify_expectations!(bypass)
     end
 
-    Mix.Config.persist bypass: [framework: :ex_unit]
+    Mix.Config.persist bypass: [test_framework: :ex_unit]
   end
 end

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -405,7 +405,7 @@ defmodule BypassTest do
 
     assert {:ok, 200, ""} = request(bypass.port)
 
-    assert_raise RuntimeError, "Not available in ExUnit, as it's det automatically.", fn ->
+    assert_raise RuntimeError, "Not available in ExUnit, as it's configured automatically.", fn ->
       Bypass.verify_expectations!(bypass)
     end
   end


### PR DESCRIPTION
Closes https://github.com/PSPDFKit-labs/bypass/issues/9 and https://github.com/PSPDFKit-labs/bypass/issues/37.

This is just an experiment at the moment, but it works in my current project that uses ESpec.

The current Bypass unit tests pass, but I'm not sure about the best way to test the integration with both libraries. I could add a bunch of integration and acceptance tests, I guess, but I'd appreciate some pointers from the maintainers.

If this change is likely to be accepted, I'll try to put some more time in polishing it.