### PR TITLE
Support catching PATCH requests in :expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Must be called exactly once.
 
 Must be called at least once.
 
-`method` is one of `["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "CONNECT"]`
+`method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
 
 `path` is the endpoint.
 
@@ -89,7 +89,7 @@ Must be called at least once.
 
 Must be called exactly once.
 
-`method` is one of `["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "CONNECT"]`
+`method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
 
 `path` is the endpoint.
 

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -109,7 +109,7 @@ defmodule Bypass.Instance do
   defp do_handle_call(
     {expect, method, path, fun}, _from, %{expectations: expectations} = state)
       when expect in [:expect, :expect_once]
-      and method in ["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "CONNECT", :any]
+      and method in ["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT", :any]
       and (is_binary(path) or path == :any)
       and is_function(fun, 1)
   do


### PR DESCRIPTION
Hi guys,

I've noticed that there is not support for `PATCH` requests and opened that PR.

Also, I'm concerned about test coverage - I didn't find tests for request methods, like `PUT`, `DELETE` etc. Am I missing something? I can help with covering it, if you need.