### PR TITLE
F/update docs

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -18,6 +18,19 @@ defmodule Bypass do
 
   Use the other functions in this module to declare which requests are
   handled and set expectations on the calls.
+
+  You can provide the following `opts`:
+
+    * `:port`      - Optional TCP port to listen on, defaults to a random assigned number
+
+  ## Examples
+
+      # Open a connection to the Bypass server on a random port
+      Bypass.open
+
+      # Open a connection on port 5678
+      iex> Bypass.open(port: 5678)
+
   """
   def open(opts \\ []) do
     case Supervisor.start_child(Bypass.Supervisor, [opts]) do
@@ -58,12 +71,12 @@ defmodule Bypass do
 
   defp verify_expectations!(:ex_unit, _bypass) do
     raise "Not available in ExUnit, as it's configured automatically."
-  end  
+  end
 
   if Code.ensure_loaded?(ESpec) do
     defp verify_expectations!(:espec, bypass) do
       do_verify_expectations(bypass.pid, ESpec.AssertionError)
-    end    
+    end
   end
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule Bypass.Mixfile do
     [app: :bypass,
      version: "0.8.1",
      elixir: "~> 1.0",
+     docs: docs(),
      description: description(),
      package: package(),
      deps: deps(Mix.env)]
@@ -45,6 +46,13 @@ defmodule Bypass.Mixfile do
     ]
   end
   defp deps(_), do: deps()
+
+  defp docs do
+    [
+      main: "Bypass",
+      extras: ["README.md", "CHANGELOG.md"],
+  ]
+  end
 
   defp description do
     """

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,9 @@ defmodule Bypass.Mixfile do
   # depend on them from hex. In order to resolv this we need to override those dependencies. But
   # since you can't publish to hex with overriden dependencies this ugly hack only pulls the
   # dependencies in when in the test env.
+  #
+  # To grab all dependencies for testing, grab your depencies using:
+  # $ MIX_ENV=test mix deps.get
   defp deps(:test) do
     deps() ++ [
       {:cowlib, "~> 1.0.1", override: true},


### PR DESCRIPTION

Updated the docs to show all available (well just the `port` really) opts for open.  Also updated the default hex docs to be the `Bypass` module, and now including both your README and CHANGELOG from your github repo.