### PR TITLE
Add stub method that does not fail expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ the socket updates its state.
 You can take any of the following approaches:
 * `expect/2` or `expect_once/2` to install a generic function that all calls to bypass will use
 * `expect/4` and/or `expect_once/4` to install specific routes (method and path)
+* `stub/4` to install specific routes without expectations
 * a combination of the above, where the routes will be used first, and then the generic version
   will be used as default
 
@@ -95,6 +96,21 @@ Must be called exactly once.
 
 ```elixir
   Bypass.expect_once bypass, "POST", "/1.1/statuses/update.json", fn conn ->
+    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no+1} end)
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end
+```
+
+#### stub/4 (bypass_instance, method, path, function)
+
+May be called none or more times.
+
+`method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
+
+`path` is the endpoint.
+
+```elixir
+  Bypass.stub bypass, "POST", "/1.1/statuses/update.json", fn conn ->
     Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no+1} end)
     Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
   end

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -58,12 +58,12 @@ defmodule Bypass do
 
   defp verify_expectations!(:ex_unit, _bypass) do
     raise "Not available in ExUnit, as it's configured automatically."
-  end  
+  end
 
   if Code.ensure_loaded?(ESpec) do
     defp verify_expectations!(:espec, bypass) do
       do_verify_expectations(bypass.pid, ESpec.AssertionError)
-    end    
+    end
   end
 
 
@@ -110,6 +110,9 @@ defmodule Bypass do
 
   def expect_once(%Bypass{pid: pid}, methods, paths, fun),
     do: Bypass.Instance.call(pid, {:expect_once, methods, paths, fun})
+
+  def stub(%Bypass{pid: pid}, methods, paths, fun),
+    do: Bypass.Instance.call(pid, {:stub, methods, paths, fun})
 
   def pass(%Bypass{pid: pid}),
     do: Bypass.Instance.call(pid, :pass)

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -108,7 +108,7 @@ defmodule Bypass.Instance do
 
   defp do_handle_call(
     {expect, method, path, fun}, _from, %{expectations: expectations} = state)
-      when expect in [:expect, :expect_once]
+      when expect in [:stub, :expect, :expect_once]
       and method in ["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT", :any]
       and (is_binary(path) or path == :any)
       and is_function(fun, 1)
@@ -123,6 +123,7 @@ defmodule Bypass.Instance do
             case expect do
               :expect -> :once_or_more
               :expect_once -> :once
+              :stub -> :none_or_more
             end
           ))
         _ ->
@@ -231,6 +232,7 @@ defmodule Bypass.Instance do
   defp expectation_problem_message(expectations) do
     problem_route =
       expectations
+      |> Enum.reject(fn {_route, expectations} -> expectations[:expected] == :none_or_more end)
       |> Enum.find(fn {_route, expectations} -> length(expectations.results) == 0 end)
 
     case problem_route do

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -280,12 +280,33 @@ defmodule BypassTest do
     end)
   end
 
+  test "Bypass.stub/4 does not raise if request is made" do
+    :stub |> specific_route
+  end
+
+  test "Bypass.stub/4 does not raise if request is not made" do
+    :stub |> set_expectation("/stub_path")
+  end
+
   test "Bypass.expect/4 can be used to define a specific route" do
     :expect |> specific_route
   end
 
   test "Bypass.expect_once/4 can be used to define a specific route" do
     :expect_once |> specific_route
+  end
+
+  defp set_expectation(action, path) do
+    bypass = Bypass.open
+    method = "POST"
+
+    apply(Bypass, action, [
+      bypass, method, path, fn conn ->
+        assert conn.method == method
+        assert conn.request_path == path
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+    ])
   end
 
   defp specific_route(expect_fun) do


### PR DESCRIPTION
## Problem
Sometimes we have http methods that may or may not be called within the context of a test. We don't want these to fail with expectations if they are not called.

Specifically, this has presented itself when we might have an asynchronous call that may or may not make a request before the test has completed.

## Solution
Adding a stub method that does not evaluate expectations allows us to stub calls without asserting expectations.