### PR TITLE
Correctly stopping server in edge case

### DIFF
--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -184,6 +184,11 @@ defmodule Bypass.Instance do
     end
   end
 
+
+  def handle_info(:stop, state) do
+    {:stop, :normal, state}
+  end
+
   defp do_exit(state) do
     updated_state =
       case state do
@@ -295,7 +300,7 @@ defmodule Bypass.Instance do
       if length(exit_callers) > 0 do
         {result, _updated_state} = do_exit(state)
         Enum.each(exit_callers, &(GenServer.reply(&1, result)))
-        GenServer.stop(:normal)
+        send(self(), :stop)
       end
 
       down_reset || state


### PR DESCRIPTION
We were receiving this error:

```elixir
16:42:32.171 [error] GenServer #PID<0.441.0> terminating
** (stop) exited in: GenServer.stop(:normal, :normal, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir) lib/gen_server.ex:783: GenServer.stop/3
    (bypass) lib/bypass/instance.ex:298: Bypass.Instance.dispatch_awaiting_callers/1
    (bypass) lib/bypass/instance.ex:173: Bypass.Instance.do_handle_call/3
    (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.452.0>): {:put_expect_result, {"GET", "/censored"}, #Reference<0.1560715534.3557556225.6561>, :ok_call}
```

My change correctly stops the GenServer in this case.