### PR TITLE
Replace cowboy dependency with plug_cowboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,6 @@ Set `:enable_debug_log` to `true` in the application environment to make Bypass 
 config :bypass, enable_debug_log: true
 ```
 
-Set `:adapter` to `Plug.Adapters.Cowboy2` for Cowboy2 support
-
-```elixir
-config :bypass, adapter: Plug.Adapters.Cowboy2
-```
-
 ## License
 
 This software is licensed under [the MIT license](LICENSE).

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -26,7 +26,6 @@ defmodule Bypass.Instance do
   # GenServer callbacks
 
   def init([opts]) do
-    adapter = adapter_from_options(opts)
     # Get a free port from the OS
     case :ranch_tcp.listen(ip: @listen_ip, port: Keyword.get(opts, :port, 0)) do
       {:ok, socket} ->
@@ -34,10 +33,9 @@ defmodule Bypass.Instance do
         :erlang.port_close(socket)
 
         ref = make_ref()
-        socket = do_up(port, ref, adapter)
+        socket = do_up(port, ref)
 
         state = %{
-          adapter: adapter,
           expectations: %{},
           port: port,
           ref: ref,
@@ -83,8 +81,8 @@ defmodule Bypass.Instance do
     {:reply, port, state}
   end
 
-  defp do_handle_call(:up, _from, %{port: port, ref: ref, socket: nil, adapter: adapter} = state) do
-    socket = do_up(port, ref, adapter)
+  defp do_handle_call(:up, _from, %{port: port, ref: ref, socket: nil} = state) do
+    socket = do_up(port, ref)
     {:reply, :ok, %{state | socket: socket}}
   end
   defp do_handle_call(:up, _from, state) do
@@ -94,12 +92,12 @@ defmodule Bypass.Instance do
   defp do_handle_call(:down, _from, %{socket: nil} = state) do
     {:reply, {:error, :already_down}, state}
   end
-  defp do_handle_call(:down, from, %{socket: socket, ref: ref, callers_awaiting_down: callers_awaiting_down, adapter: adapter} = state) when not is_nil(socket) do
+  defp do_handle_call(:down, from, %{socket: socket, ref: ref, callers_awaiting_down: callers_awaiting_down} = state) when not is_nil(socket) do
     if retained_plugs_count(state) > 0 do
       # wait for plugs to finish
       {:noreply, %{state | callers_awaiting_down: [from | callers_awaiting_down]}}
     else
-      do_down(ref, socket, adapter)
+      do_down(ref, socket)
       {:reply, :ok, %{state | socket: nil}}
     end
   end
@@ -187,12 +185,12 @@ defmodule Bypass.Instance do
     end
   end
 
-  defp do_exit(%{adapter: adapter} = state) do
+  defp do_exit(state) do
     updated_state =
       case state do
         %{socket: nil} -> state
         %{socket: socket, ref: ref} ->
-          do_down(ref, socket, adapter)
+          do_down(ref, socket)
           %{state | socket: nil}
       end
 
@@ -264,16 +262,16 @@ defmodule Bypass.Instance do
     {route, Map.get(expectations, route)}
   end
 
-  defp do_up(port, ref, adapter) do
+  defp do_up(port, ref) do
     plug_opts = [self()]
     {:ok, socket} = :ranch_tcp.listen(ip: @listen_ip, port: port)
-    cowboy_opts = [ref: ref, acceptors: 5, port: port, socket: socket]
-    {:ok, _pid} = adapter.http(Bypass.Plug, plug_opts, cowboy_opts)
+    cowboy_opts = [ref: ref, port: port, transport_options: [num_acceptors: 5, socket: socket]]
+    {:ok, _pid} = Plug.Cowboy.http(Bypass.Plug, plug_opts, cowboy_opts)
     socket
   end
 
-  defp do_down(ref, socket, adapter) do
-    :ok = adapter.shutdown(ref)
+  defp do_down(ref, socket) do
+    :ok = Plug.Cowboy.shutdown(ref)
 
     # `port_close` is synchronous, so after it has returned we _know_ that the socket has been
     # closed. If we'd rely on ranch's supervisor shutting down the acceptor processes and thereby
@@ -286,12 +284,12 @@ defmodule Bypass.Instance do
   end
 
   defp dispatch_awaiting_callers(%{callers_awaiting_down: down_callers,
-    callers_awaiting_exit: exit_callers, socket: socket, ref: ref, adapter: adapter} = state) do
+    callers_awaiting_exit: exit_callers, socket: socket, ref: ref} = state) do
 
     if retained_plugs_count(state) == 0 do
       down_reset =
         if length(down_callers) > 0 do
-          do_down(ref, socket, adapter)
+          do_down(ref, socket)
           Enum.each(down_callers, &(GenServer.reply(&1, :ok)))
           %{state | socket: nil, callers_awaiting_down: []}
         end
@@ -323,13 +321,5 @@ defmodule Bypass.Instance do
       results: [],
       request_count: 0
     }
-  end
-
-  defp adapter_from_options(opts) do
-    case Keyword.get(opts, :adapter) do
-      nil ->
-        Application.get_env(:bypass, :adapter)
-      adapter -> adapter
-    end
   end
 end

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -265,7 +265,7 @@ defmodule Bypass.Instance do
   defp do_up(port, ref) do
     plug_opts = [self()]
     {:ok, socket} = :ranch_tcp.listen(ip: @listen_ip, port: port)
-    cowboy_opts = [ref: ref, port: port, transport_options: [num_acceptors: 5, socket: socket]]
+    cowboy_opts = cowboy_opts(port, ref, socket)
     {:ok, _pid} = Plug.Cowboy.http(Bypass.Plug, plug_opts, cowboy_opts)
     socket
   end
@@ -321,5 +321,12 @@ defmodule Bypass.Instance do
       results: [],
       request_count: 0
     }
+  end
+
+  defp cowboy_opts(port, ref, socket) do
+    case Application.spec(:plug_cowboy, :vsn) do
+      '1.' ++ _ -> [ref: ref, acceptors: 5, port: port, socket: socket]
+      _ -> [ref: ref, port: port, transport_options: [num_acceptors: 5, socket: socket]]
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,15 +18,15 @@ defmodule Bypass.Mixfile do
 
   defp deps do
     [
-      {:cowboy, "~> 1.0 or ~> 2.0",},
-      {:plug, "~> 1.0"},
+      {:plug_cowboy, "~> 1.0 or ~> 2.0",},
+      {:plug, "~> 1.7"},
       {:ex_doc, "> 0.0.0", only: :dev},
       {:espec, "~> 1.4", only: [:dev, :test]},
     ]
   end
 
   defp env do
-    [enable_debug_log: false, adapter: Plug.Adapters.Cowboy]
+    [enable_debug_log: false]
   end
 
   # We need to work around the fact that gun would pull in cowlib/ranch from git, while cowboy/plug

--- a/mix.exs
+++ b/mix.exs
@@ -11,14 +11,14 @@ defmodule Bypass.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :ranch, :cowboy, :plug],
+    [applications: [:logger, :ranch, :cowboy, :plug, :plug_cowboy],
      mod: {Bypass.Application, []},
      env: env()]
   end
 
   defp deps do
     [
-      {:plug_cowboy, "~> 1.0 or ~> 2.0",},
+      {:plug_cowboy, "~> 1.0 or ~> 2.0"},
       {:plug, "~> 1.7"},
       {:ex_doc, "> 0.0.0", only: :dev},
       {:espec, "~> 1.4", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,14 @@
-%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
-  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
+%{
+  "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
   "espec": {:hex, :espec, "1.4.1", "d453c32835736bb01b68b32b571fb23ad307f019c33952602a17e3a9b6e6e9b0", [:mix], [{:meck, "0.8.4", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gun": {:git, "https://github.com/PSPDFKit-labs/gun.git", "0462585ec7b0bcb2ca4b8b91e6d2624a45324b6e", []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
-  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}], "hexpm"},
-  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], [], "hexpm"}}
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.7.0", "cd8c8de89bd9de55eba1c918bf0e7f319737e109b6014875104af025a623e16e", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+  "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
-%{
-  "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
-  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+%{"cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm"},
   "espec": {:hex, :espec, "1.4.1", "d453c32835736bb01b68b32b571fb23ad307f019c33952602a17e3a9b6e6e9b0", [:mix], [{:meck, "0.8.4", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
@@ -9,6 +8,6 @@
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.7.0", "cd8c8de89bd9de55eba1c918bf0e7f319737e109b6014875104af025a623e16e", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_cowboy": {:hex, :plug_cowboy, "1.0.0", "2e2a7d3409746d335f451218b8bb0858301c3de6d668c3052716c909936eb57a", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
-  "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
-}
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"}}


### PR DESCRIPTION
Plug 1.7 extract `Plug.Adapters.Cowboy` and `Plug.Adapters.Cowboy2` into [plug_cowboy](https://github.com/elixir-plug/plug_cowboy).

So we can remove some configuration and use `Plug.Cowboy` directly.