### PR TITLE
Make listen interface configurable

### DIFF
--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -3,11 +3,6 @@ defmodule Bypass.Instance do
 
   import Bypass.Utils
 
-  # This is used to override the default behaviour of ranch_tcp
-  # and limit the range of interfaces it will listen on to just
-  # the loopback interface.
-  @listen_ip {127, 0, 0, 1}
-
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, [opts])
   end
@@ -27,7 +22,7 @@ defmodule Bypass.Instance do
 
   def init([opts]) do
     # Get a free port from the OS
-    case :ranch_tcp.listen(ip: @listen_ip, port: Keyword.get(opts, :port, 0)) do
+    case :ranch_tcp.listen(ip: listen_ip(), port: Keyword.get(opts, :port, 0)) do
       {:ok, socket} ->
         {:ok, port} = :inet.port(socket)
         :erlang.port_close(socket)
@@ -264,7 +259,7 @@ defmodule Bypass.Instance do
 
   defp do_up(port, ref) do
     plug_opts = [self()]
-    {:ok, socket} = :ranch_tcp.listen(ip: @listen_ip, port: port)
+    {:ok, socket} = :ranch_tcp.listen(ip: listen_ip(), port: port)
     cowboy_opts = cowboy_opts(port, ref, socket)
     {:ok, _pid} = Plug.Cowboy.http(Bypass.Plug, plug_opts, cowboy_opts)
     socket
@@ -328,5 +323,16 @@ defmodule Bypass.Instance do
       '1.' ++ _ -> [ref: ref, acceptors: 5, port: port, socket: socket]
       _ -> [ref: ref, port: port, transport_options: [num_acceptors: 5, socket: socket]]
     end
+  end
+
+  # This is used to override the default behaviour of ranch_tcp
+  # and limit the range of interfaces it will listen on to just
+  # the configured interface. Loopback is a default interface.
+  defp listen_ip do
+    Application.get_env(:bypass, :listen_ip, "127.0.0.1")
+    |> String.split(".")
+    |> Enum.map(&Integer.parse/1)
+    |> Enum.map(&elem(&1, 0))
+    |> List.to_tuple()
   end
 end


### PR DESCRIPTION
We have a special use case which requires to use bypass in a docker compose so it should be able to receive requests coming from other containers. 
This PR makes _listen_ip_ configurable and keeps loopback as a default interface.

Solving #11 