### PR TITLE
Add links to source code from docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,19 +5,23 @@ defmodule Bypass.Mixfile do
   @source_url "https://github.com/PSPDFKit-labs/bypass"
 
   def project do
-    [app: :bypass,
-     version: @version,
-     elixir: "~> 1.0",
-     description: description(),
-     package: package(),
-     deps: deps(Mix.env),
-     docs: docs()]
+    [
+      app: :bypass,
+      version: @version,
+      elixir: "~> 1.0",
+      description: description(),
+      package: package(),
+      deps: deps(Mix.env()),
+      docs: docs()
+    ]
   end
 
   def application do
-    [applications: [:logger, :ranch, :cowboy, :plug, :plug_cowboy],
-     mod: {Bypass.Application, []},
-     env: env()]
+    [
+      applications: [:logger, :ranch, :cowboy, :plug, :plug_cowboy],
+      mod: {Bypass.Application, []},
+      env: env()
+    ]
   end
 
   defp deps do
@@ -25,7 +29,7 @@ defmodule Bypass.Mixfile do
       {:plug_cowboy, "~> 1.0 or ~> 2.0"},
       {:plug, "~> 1.7"},
       {:ex_doc, "> 0.0.0", only: :dev},
-      {:espec, "~> 1.6", only: [:dev, :test]},
+      {:espec, "~> 1.6", only: [:dev, :test]}
     ]
   end
 
@@ -38,13 +42,14 @@ defmodule Bypass.Mixfile do
   # since you can't publish to hex with overriden dependencies this ugly hack only pulls the
   # dependencies in when in the test env.
   defp deps(:test) do
-    deps() ++ [
-      {:cowlib, "~> 1.0.1", override: true},
-      {:ranch, "~> 1.2.0", override: true},
-
-      {:gun, github: "PSPDFKit-labs/gun", only: :test}
-    ]
+    deps() ++
+      [
+        {:cowlib, "~> 1.0.1", override: true},
+        {:ranch, "~> 1.2.0", override: true},
+        {:gun, github: "PSPDFKit-labs/gun", only: :test}
+      ]
   end
+
   defp deps(_), do: deps()
 
   defp docs do
@@ -71,7 +76,7 @@ defmodule Bypass.Mixfile do
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
-        "PSPDFKit" => "https://pspdfkit.com",
+        "PSPDFKit" => "https://pspdfkit.com"
       }
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,17 @@
 defmodule Bypass.Mixfile do
   use Mix.Project
 
+  @version "1.0.0"
+  @source_url "https://github.com/PSPDFKit-labs/bypass"
+
   def project do
     [app: :bypass,
-     version: "1.0.0",
+     version: @version,
      elixir: "~> 1.0",
      description: description(),
      package: package(),
-     deps: deps(Mix.env)]
+     deps: deps(Mix.env),
+     docs: docs()]
   end
 
   def application do
@@ -43,6 +47,14 @@ defmodule Bypass.Mixfile do
   end
   defp deps(_), do: deps()
 
+  defp docs do
+    [
+      main: "Bypass",
+      source_url: @source_url,
+      source_ref: "v#{@version}"
+    ]
+  end
+
   defp description do
     """
     Bypass provides a quick way to create a custom plug that can be put in place instead of an
@@ -58,7 +70,7 @@ defmodule Bypass.Mixfile do
       maintainers: ["PSPDFKit"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/pspdfkit-labs/bypass",
+        "GitHub" => @source_url,
         "PSPDFKit" => "https://pspdfkit.com",
       }
     ]


### PR DESCRIPTION
This adds links to the source code from ExDocs.

<img width="461" alt="Screen Shot 2019-05-11 at 9 43 28 PM" src="https://user-images.githubusercontent.com/120878/57577565-2f791b00-7437-11e9-8bc2-41537d05884e.png">

As a user, it's nice when a project has these links so I can quickly see how a function is implemented.