### PR TITLE
Remove warning on 1.10

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -20,7 +20,7 @@ defmodule Bypass do
   handled and set expectations on the calls.
   """
   def open(opts \\ []) do
-    case Supervisor.start_child(Bypass.Supervisor, [opts]) do
+    case DynamicSupervisor.start_child(Bypass.DynamicSupervisor, {Bypass.Instance, opts}) do
       {:ok, pid} ->
         port = Bypass.Instance.call(pid, :port)
         debug_log "Did open connection #{inspect pid} on port #{inspect port}"

--- a/lib/bypass/application.ex
+++ b/lib/bypass/application.ex
@@ -5,10 +5,11 @@ defmodule Bypass.Application do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(Bypass.Instance, [], restart: :transient)
+      worker(Bypass.Instance, [], restart: :transient),
+      {DynamicSupervisor, strategy: :one_for_one, name: Bypass.DynamicSupervisor}
     ]
 
-    opts = [strategy: :simple_one_for_one, name: Bypass.Supervisor]
+    opts = [strategy: :one_for_one, name: Bypass.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/bypass/application.ex
+++ b/lib/bypass/application.ex
@@ -2,10 +2,7 @@ defmodule Bypass.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
-      worker(Bypass.Instance, [], restart: :transient),
       {DynamicSupervisor, strategy: :one_for_one, name: Bypass.DynamicSupervisor}
     ]
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "plug": {:hex, :plug, "1.7.0", "cd8c8de89bd9de55eba1c918bf0e7f319737e109b6014875104af025a623e16e", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "1.0.0", "2e2a7d3409746d335f451218b8bb0858301c3de6d668c3052716c909936eb57a", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
-  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
+  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], [], "hexpm"},
 }


### PR DESCRIPTION
The old, deprecated, `:simple_one_for_one` strategy for supervisors now causes a verbose warning on Elixir 1.10. Switching to a `DynamicSupervisor` is the recommended replacement.

This PR is a half ready attempt at switching to this but I have some failing tests possibly caused by my naive approach to replacement, so far I've tried o add a dynamic supervisor child to the application supervisor, then to start instances on the dynamic supervisor.

The tests fail because sometimes the dynamic supervisor isn't alive? I'm not sure why that is...