### PR TITLE
Parametric route

### DIFF
--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -308,29 +308,25 @@ defmodule Bypass.Instance do
     {route, Map.get(expectations, route)}
   end
 
-  defp match_route(path, route) do
-    case length(path) == length(route) do
-      true ->
-        path
-        |> Enum.zip(route)
-        |> Enum.reduce_while(
-          {true, %{}},
-          fn
-            {value, {param, _, _}}, {_, params} ->
-              {:cont, {true, Map.put(params, Atom.to_string(param), value)}}
+  defp match_route(path, route) when length(path) == length(route) do
+    path
+    |> Enum.zip(route)
+    |> Enum.reduce_while(
+      {true, %{}},
+      fn
+        {value, {param, _, _}}, {_, params} ->
+          {:cont, {true, Map.put(params, Atom.to_string(param), value)}}
 
-            {segment, segment}, acc ->
-              {:cont, acc}
+        {segment, segment}, acc ->
+          {:cont, acc}
 
-            _, _ ->
-              {:halt, {false, nil}}
-          end
-        )
-
-      false ->
-        {false, nil}
-    end
+        _, _ ->
+          {:halt, {false, nil}}
+      end
+    )
   end
+
+  defp match_route(_, _), do: {false, nil}
 
   defp do_up(port, ref) do
     plug_opts = [self()]

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -2,6 +2,7 @@ defmodule Bypass.Instance do
   use GenServer, restart: :transient
 
   import Bypass.Utils
+  import Plug.Router.Utils, only: [build_path_match: 1]
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, [opts])
@@ -139,6 +140,7 @@ defmodule Bypass.Instance do
         route,
         new_route(
           fun,
+          path,
           case expect do
             :expect -> :once_or_more
             :expect_once -> :once
@@ -285,16 +287,49 @@ defmodule Bypass.Instance do
   end
 
   defp route_info(method, path, %{expectations: expectations} = _state) do
-    route =
-      case Map.get(expectations, {method, path}, :no_expectations) do
-        :no_expectations ->
-          {:any, :any}
+    segments = build_path_match(path) |> elem(1)
 
-        _ ->
-          {method, path}
-      end
+    route =
+      expectations
+      |> Enum.reduce_while(
+        {:any, :any, %{}},
+        fn
+          {{^method, path_pattern}, %{path_parts: path_parts}}, acc ->
+            case match_route(segments, path_parts) do
+              {true, params} -> {:halt, {method, path_pattern, params}}
+              {false, _} -> {:cont, acc}
+            end
+
+          _, acc ->
+            {:cont, acc}
+        end
+      )
 
     {route, Map.get(expectations, route)}
+  end
+
+  defp match_route(path, route) do
+    case length(path) == length(route) do
+      true ->
+        path
+        |> Enum.zip(route)
+        |> Enum.reduce_while(
+          {true, %{}},
+          fn
+            {value, {param, _, _}}, {_, params} ->
+              {:cont, {true, Map.put(params, Atom.to_string(param), value)}}
+
+            {segment, segment}, acc ->
+              {:cont, acc}
+
+            _, _ ->
+              {:halt, {false, nil}}
+          end
+        )
+
+      false ->
+        {false, nil}
+    end
   end
 
   defp do_up(port, ref) do
@@ -353,15 +388,22 @@ defmodule Bypass.Instance do
     |> length
   end
 
-  defp new_route(fun, expected) do
+  defp new_route(fun, path_parts, expected) when is_list(path_parts) do
     %{
       fun: fun,
       expected: expected,
+      path_parts: path_parts,
       retained_plugs: %{},
       results: [],
       request_count: 0
     }
   end
+
+  defp new_route(fun, :any, expected),
+    do: new_route(fun, [], expected)
+
+  defp new_route(fun, path, expected),
+    do: new_route(fun, build_path_match(path) |> elem(1), expected)
 
   defp cowboy_opts(port, ref, socket) do
     case Application.spec(:plug_cowboy, :vsn) do

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -2,8 +2,11 @@ defmodule Bypass.Plug do
   def init([pid]), do: pid
 
   def call(%{method: method, request_path: request_path} = conn, pid) do
-    route = Bypass.Instance.call(pid, {:get_route, method, request_path})
+    {method, path, path_params} = Bypass.Instance.call(pid, {:get_route, method, request_path})
+    route = {method, path}
     ref = make_ref()
+
+    conn = Plug.Conn.fetch_query_params(%{conn | params: path_params})
 
     case Bypass.Instance.call(pid, {:get_expect_fun, route}) do
       fun when is_function(fun, 1) ->


### PR DESCRIPTION
This adds support for parameters in expectation url. 

You can define expectation like this:
```elixir
Bypass.expect_once(bypass, "GET", "/1.1/users/:user_id", fn conn ->
    user_id = Map.get(conn.params, "user_id)
    Plug.Conn.resp(conn, 200, ~s<{....}>)
end)
```

and the request `client->get("http://localhost:8080/1.1/users/1234")` will successfully match the expectation defined above.