### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,39 @@
 
 <!-- MDOC !-->
 
-`Bypass` provides a quick way to create a custom plug that can be put in place instead of an actual
-HTTP server to return prebaked responses to client requests. This is most useful in tests, when you
-want to create a mock HTTP server and test how your HTTP client handles different types of
-responses from the server.
+`Bypass` provides a quick way to create a custom plug that can be put in place
+instead of an actual HTTP server to return prebaked responses to client
+requests. This is most useful in tests, when you want to create a mock HTTP
+server and test how your HTTP client handles different types of responses from
+the server.
 
 Bypass supports Elixir 1.6 and OTP 20 and up. It works with Cowboy 1 and 2.
 
 ## Usage
 
-To use Bypass in a test case, open a connection and use its port to connect your client to it.
+To use Bypass in a test case, open a connection and use its port to connect your
+client to it.
 
-If you want to test what happens when the HTTP server goes down, use `Bypass.down/1` to close the
-TCP socket and `Bypass.up/1` to start listening on the same port again. Both functions block until
-the socket updates its state.
+If you want to test what happens when the HTTP server goes down, use
+`Bypass.down/1` to close the TCP socket and `Bypass.up/1` to start listening on
+the same port again. Both functions block until the socket updates its state.
 
 ### Expect Functions
 
 You can take any of the following approaches:
-* `expect/2` or `expect_once/2` to install a generic function that all calls to bypass will use
+
+* `expect/2` or `expect_once/2` to install a generic function that all calls to
+  bypass will use
 * `expect/4` and/or `expect_once/4` to install specific routes (method and path)
 * `stub/4` to install specific routes without expectations
-* a combination of the above, where the routes will be used first, and then the generic version
-  will be used as default
+* a combination of the above, where the routes will be used first, and then the
+  generic version will be used as default
 
 ### Example
 
-In the following example `TwitterClient.start_link()` takes the endpoint URL as its argument
-allowing us to make sure it will connect to the running instance of Bypass.
+In the following example `TwitterClient.start_link()` takes the endpoint URL as
+its argument allowing us to make sure it will connect to the running instance of
+Bypass.
 
 ```elixir
 defmodule TwitterClientTest do
@@ -81,26 +86,31 @@ defmodule TwitterClientTest do
 end
 ```
 
-That's all you need to do. Bypass automatically sets up an `on_exit` hook to close its socket when
-the test finishes running.
+That's all you need to do. Bypass automatically sets up an `on_exit` hook to
+close its socket when the test finishes running.
 
-Multiple concurrent Bypass instances are supported, all will have a different unique port.  Concurrent
-requests are also supported on the same instance.
+Multiple concurrent Bypass instances are supported, all will have a different
+unique port.  Concurrent requests are also supported on the same instance.
 
-> Note: `Bypass.open/0` **must not** be called in a `setup_all` blocks due to the way Bypass verifies the expectations at the end of each
-> test.
+> Note: `Bypass.open/0` **must not** be called in a `setup_all` blocks due to
+> the way Bypass verifies the expectations at the end of each test.
 
 ## How to use with ESpec
 
-While Bypass primarily targets ExUnit, the official Elixir builtin test framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The test configuration is basically the same, there are only two differences:
+While Bypass primarily targets ExUnit, the official Elixir builtin test
+framework, it can also be used with [ESpec](https://hex.pm/packages/espec). The
+test configuration is basically the same, there are only two differences:
 
-1. In your Mix config file, you must declare which test framework Bypass is being used with (defaults to `:ex_unit`). This simply disables the automatic integration with some hooks provided by `ExUnit`.
+1. In your Mix config file, you must declare which test framework Bypass is
+   being used with (defaults to `:ex_unit`). This simply disables the automatic
+   integration with some hooks provided by `ExUnit`.
 
 ```elixir
 config :bypass, test_framework: :espec
 ```
 
-2. In your specs, you must explicitly verify the declared expectations. You can do it in the `finally` block.
+2. In your specs, you must explicitly verify the declared expectations. You can
+   do it in the `finally` block.
 
 ```elixir
 defmodule TwitterClientSpec do
@@ -130,7 +140,8 @@ end
 
 ## Configuration options
 
-Set `:enable_debug_log` to `true` in the application environment to make Bypass log what it's doing:
+Set `:enable_debug_log` to `true` in the application environment to make Bypass
+log what it's doing:
 
 ```elixir
 config :bypass, enable_debug_log: true
@@ -145,12 +156,13 @@ Add bypass to your list of dependencies in mix.exs:
 ```elixir
 def deps do
   [
-    {:bypass, "~> 1.0", only: :test}
+    {:bypass, "~> 2.0", only: :test}
   ]
 end
 ```
 
-We do not recommended adding `:bypass` to the list of applications in your `mix.exs`.
+We do not recommended adding `:bypass` to the list of applications in your
+`mix.exs`.
 
 ## License
 
@@ -164,8 +176,10 @@ This software is licensed under [the MIT license](LICENSE).
 
 This project is maintained and funded by [PSPDFKit](https://pspdfkit.com/).
 
-Please ensure
-[you signed our CLA](https://pspdfkit.com/guides/web/current/miscellaneous/contributing/) so we can
-accept your contributions.
+Please ensure [you signed our
+CLA](https://pspdfkit.com/guides/web/current/miscellaneous/contributing/) so we
+can accept your contributions.
 
-See [our other open source projects](https://github.com/PSPDFKit-labs), read [our blog](https://pspdfkit.com/blog/) or say hello on Twitter ([@PSPDFKit](https://twitter.com/pspdfkit)).
+See [our other open source projects](https://github.com/PSPDFKit-labs), read
+[our blog](https://pspdfkit.com/blog/) or say hello on Twitter
+([@PSPDFKit](https://twitter.com/pspdfkit)).

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -24,7 +24,7 @@ defmodule Bypass do
 
   ## Options
 
-  - `port` - Optional TCP port to listen to requests
+  - `port` - Optional TCP port to listen to requests.
 
   ## Examples
 


### PR DESCRIPTION
## Motivation 

Ref #98 

## Proposed solution

- Use the approach mentioned at #98 to use part of the README as moduledoc of the main module.
- Add typespec for the public functions
- Move the docs of each function to their own `@doc` blocks