### PR TITLE
Remove Supervisor.Spec import

### DIFF
--- a/lib/bypass/application.ex
+++ b/lib/bypass/application.ex
@@ -4,8 +4,6 @@ defmodule Bypass.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     opts = [strategy: :one_for_one, name: Bypass.Supervisor]
     DynamicSupervisor.start_link(opts)
   end


### PR DESCRIPTION
## Motivation

The module `Supervisor.Spec` is deprecated. https://hexdocs.pm/elixir/Supervisor.Spec.html
And seems that we don't use any of the imported functions.

## Proposed solution

Remove the import