### PR TITLE
Raise on Bypass.open/1 errors

### DIFF
--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -584,4 +584,10 @@ defmodule BypassTest do
 
     Mix.Config.persist(bypass: [test_framework: :ex_unit])
   end
+
+  test "Bypass.open/1 raises when cannot start child" do
+    assert_raise RuntimeError, ~r/Failed to start bypass instance/, fn ->
+      Bypass.open(:error)
+    end
+  end
 end


### PR DESCRIPTION
## Motivation

According to comment https://github.com/PSPDFKit-labs/bypass/pull/92#issuecomment-638101755 bypass takes the approach of trying to crash during the startup to avoid adding to the user the burden to handle errors. However the `open/1` function returns an error tuple in case any problem happens during the process start.

## Proposed solution

Based on the `start_supervised!/2` function from ex_unit, https://github.com/elixir-lang/elixir/blob/master/lib/ex_unit/lib/ex_unit/callbacks.ex#L424, raise an exception in case any error happens when starting the bypass process at `Bypass.open/1`.