### PR TITLE
Add release date for v2.0.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.0.0 - TBA
+## v2.0.0 - 19 Aug 2020
 
 * Allow the redefinition of routes.
 * Make listen interface configurable.


### PR DESCRIPTION
💁 This change backfills the release date of version 2.0.0. Thank you for your work on Bypass!