### PR TITLE
RemoveStacktraceDeprecations

### DIFF
--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -22,10 +22,12 @@ defmodule Bypass.Plug do
             conn
         catch
           class, reason ->
-            stacktrace = if Version.match?(System.version(), ">= 1.7.0") do
-              __STACKTRACE__
-            else
-              System.stacktrace()
+            stacktrace = unquote do
+              if Version.match?(System.version(), ">= 1.7.0") do
+                quote do: __STACKTRACE__
+              else
+                quote do: System.stacktrace()
+              end
             end
             put_result(pid, route, ref, {:exit, {class, reason, stacktrace}})
             :erlang.raise(class, reason, stacktrace)

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -22,8 +22,13 @@ defmodule Bypass.Plug do
             conn
         catch
           class, reason ->
-            put_result(pid, route, ref, {:exit, {class, reason, __STACKTRACE__}})
-            :erlang.raise(class, reason, __STACKTRACE__)
+            stacktrace = if Version.match?(System.version(), ">= 1.7.0") do
+              __STACKTRACE__
+            else
+              System.stacktrace()
+            end
+            put_result(pid, route, ref, {:exit, {class, reason, stacktrace}})
+            :erlang.raise(class, reason, stacktrace)
         end
 
       {:error, error, route} ->

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -22,9 +22,8 @@ defmodule Bypass.Plug do
             conn
         catch
           class, reason ->
-            stacktrace = System.stacktrace()
-            put_result(pid, route, ref, {:exit, {class, reason, stacktrace}})
-            :erlang.raise(class, reason, stacktrace)
+            put_result(pid, route, ref, {:exit, {class, reason, __STACKTRACE__}})
+            :erlang.raise(class, reason, __STACKTRACE__)
         end
 
       {:error, error, route} ->


### PR DESCRIPTION
Replacing all instances of System.stacktrace() with __STACKTRACE__ as per compiler warnings in Elixir 1.11