### PR TITLE
Add endpoint_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ defmodule TwitterClientTest do
       Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
     end)
 
-    {:ok, client} = TwitterClient.start_link(url: endpoint_url(bypass.port))
+    {:ok, client} = TwitterClient.start_link(url: bypass.endpoint_url)
     assert {:error, :rate_limited} == TwitterClient.post_tweet(client, "Elixir is awesome!")
   end
 
@@ -68,7 +68,7 @@ defmodule TwitterClientTest do
       Plug.Conn.resp(conn, 200, "")
     end)
 
-    {:ok, client} = TwitterClient.start_link(url: endpoint_url(bypass.port))
+    {:ok, client} = TwitterClient.start_link(url: bypass.endpoint_url)
 
     assert :ok == TwitterClient.post_tweet(client, "Elixir is awesome!")
 
@@ -85,8 +85,6 @@ defmodule TwitterClientTest do
 
     assert :ok == TwitterClient.post_tweet(client, "Elixir is awesome!")
   end
-
-  defp endpoint_url(port), do: "http://localhost:#{port}/"
 end
 ```
 
@@ -134,11 +132,9 @@ test configuration is basically the same, there are only two differences:
          Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
        end)
 
-       {:ok, client} = TwitterClient.start_link(url: endpoint_url(shared.bypass.port))
+       {:ok, client} = TwitterClient.start_link(url: shared.bypass.endpoint_url))
        assert {:error, :rate_limited} == TwitterClient.post_tweet(client, "Elixir is awesome!")
      end
-
-     defp endpoint_url(port), do: "http://localhost:#{port}/"
    end
    ```
 

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -5,12 +5,12 @@ defmodule Bypass do
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
 
-  defstruct pid: nil, port: nil
+  defstruct pid: nil, port: nil, endpoint_url: nil
 
   @typedoc """
   Represents a Bypass server process.
   """
-  @type t :: %__MODULE__{pid: pid, port: non_neg_integer}
+  @type t :: %__MODULE__{pid: pid, port: non_neg_integer, endpoint_url: String.t()}
 
   import Bypass.Utils
   require Logger
@@ -44,7 +44,7 @@ defmodule Bypass do
     pid = start_instance(opts)
     port = Bypass.Instance.call(pid, :port)
     debug_log("Did open connection #{inspect(pid)} on port #{inspect(port)}")
-    bypass = %Bypass{pid: pid, port: port}
+    bypass = %Bypass{pid: pid, port: port, endpoint_url: "http://localhost:#{port}/"}
     setup_framework_integration(test_framework(), bypass)
     bypass
   end

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -587,4 +587,9 @@ defmodule BypassTest do
       Bypass.open(:error)
     end
   end
+
+  test "Bypass.open/1 open fills endpoint_url" do
+    bypass = Bypass.open(port: 8000)
+    assert bypass.endpoint_url == "http://localhost:8000/"
+  end
 end


### PR DESCRIPTION
## Motivation

Sometime can be a little annoying to add the `endpoint_url` to every test file or add it to the test case.
As the endpoint url is something that in the majority of times the test needs to interact to be able to use bypass, seems to make sense that it could be grabbed easily. The port seems to be something more internal that not all tests would need to know and use.

## Proposed Solution

Add `endpoint_url` field to bypass struct. Existing code would work normally with existing `port` attribute. 