### PR TITLE
Add `Bypass.stub/2`

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -224,6 +224,21 @@ defmodule Bypass do
     do: Bypass.Instance.call(pid, {:expect_once, method, path, fun})
 
   @doc """
+  Allows the function to be invoked zero or many times regardless of the route
+  or HTTP method.
+
+  ```elixir
+  Bypass.stub(bypass, fn conn ->
+    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no + 1} end)
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end)
+  ```
+  """
+  @spec stub(Bypass.t(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
+  def stub(%Bypass{pid: pid}, fun),
+    do: Bypass.Instance.call(pid, {:stub, :any, :any, fun})
+
+  @doc """
   Allows the function to be invoked zero or many times for the specified route (method and path).
 
   - `method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -301,7 +301,7 @@ defmodule BypassTest do
     :stub |> set_expectation("/stub_path")
   end
 
-  test "Bypass.stub/4 allows stubbing all paths and http methods" do
+  test "Bypass.stub/2 allows stubbing all paths and http methods" do
     bypass = Bypass.open()
     parent = self()
 


### PR DESCRIPTION
This adds `Bypass.stub/2` as a version of `Bypass.expect/2` that does not require any requests to be made.

## Purpose

I love how easy it is to spin up a dynamic HTTP server with `Bypass`, but I've found sometimes it's easier to use `Plug.Router` to build a reusable backend that holds state instead of bypass.

```elixir
defmodule MySimulator.Router do
  use Plug.Router
  
  def stub_responses(bypass) do
    Bypass.stub(server.bypass, :any, :any, fn conn ->
      call(conn, init([])
    end)
  end
  
  plug :match
  plug :fetch_query_params
  
  plug Plug.Parsers,
    parsers: [:json],
    pass: ["application/json"},
    json_decoder: Jason
  
  plug :dispatch

  post "/my_route" #...
  post "/my_other_route" #...
end
```

This currently works, but passing `:any` for the HTTP Method and Path is undocumented and causes dialyzer warnings. After some testing, I noticed both the HTTP Method and Path have to be set to `:any` or the server errors.

## The fix

I really like `Bypass.expect/2` because it allows you to stub any method and path, but I need something that's OK if it isn't called. It seems like `Bypass.stub/2` makes sense. I also added tests for this function to ensure it continues to work.