### PR TITLE
Support expectation on exact number of requests

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -179,6 +179,18 @@ defmodule Bypass do
   def expect(%Bypass{pid: pid}, fun),
     do: Bypass.Instance.call(pid, {:expect, fun})
 
+  @doc """
+  Expects the passed function to be called exactly `n` times for any route.
+
+  ```elixir
+  Bypass.expect(bypass, 3, fn conn ->
+    assert "/1.1/statuses/update.json" == conn.request_path
+    assert "POST" == conn.method
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end)
+  ```
+  """
+  @spec expect(Bypass.t(), pos_integer(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
   def expect(%Bypass{pid: pid}, n, fun),
     do: Bypass.Instance.call(pid, {:expect, n, fun})
 
@@ -200,6 +212,23 @@ defmodule Bypass do
   def expect(%Bypass{pid: pid}, method, path, fun),
     do: Bypass.Instance.call(pid, {:expect, method, path, fun})
 
+  @doc """
+  Expects the passed function to be called exactly `n` times for the specified route (method and path).
+
+  - `method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
+
+  - `path` is the endpoint.
+
+  - `n` is the number of times the route is expected to be called.
+
+  ```elixir
+  Bypass.expect(bypass, "POST", "/1.1/statuses/update.json", 3, fn conn ->
+    Agent.update(AgentModule, fn step_no -> step_no + 1 end)
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end)
+  ```
+  """
+  @spec expect(Bypass.t(), String.t(), String.t(), pos_integer(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
   def expect(%Bypass{pid: pid}, method, path, n, fun),
     do: Bypass.Instance.call(pid, {{:exactly, n}, method, path, fun})
 

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -203,7 +203,7 @@ defmodule Bypass do
 
   ```elixir
   Bypass.expect(bypass, "POST", "/1.1/statuses/update.json", fn conn ->
-    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no + 1} end)
+    Agent.update(AgentModule, fn step_no -> step_no + 1 end)
     Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
   end)
   ```
@@ -256,7 +256,7 @@ defmodule Bypass do
 
   ```elixir
   Bypass.expect_once(bypass, "POST", "/1.1/statuses/update.json", fn conn ->
-    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no + 1} end)
+    Agent.update(AgentModule, fn step_no -> step_no + 1 end)
     Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
   end)
   ```
@@ -274,7 +274,7 @@ defmodule Bypass do
 
   ```elixir
   Bypass.stub(bypass, "POST", "/1.1/statuses/update.json", fn conn ->
-    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no + 1} end)
+    Agent.update(AgentModule, fn step_no -> step_no + 1 end)
     Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
   end)
   ```

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -115,6 +115,13 @@ defmodule Bypass do
       {:error, :too_many_requests, {method, path}} ->
         raise error_module, "Expected only one HTTP request for Bypass at #{method} #{path}"
 
+      {:error, {:unexpected_request_number, expected, actual}, {:any, :any}} ->
+        raise error_module, "Expected #{expected} HTTP request for Bypass, got #{actual}"
+
+      {:error, {:unexpected_request_number, expected, actual}, {method, path}} ->
+        raise error_module,
+              "Expected #{expected} HTTP request for Bypass at #{method} #{path}, got #{actual}"
+
       {:error, :unexpected_request, {:any, :any}} ->
         raise error_module, "Bypass got an HTTP request but wasn't expecting one"
 
@@ -172,6 +179,9 @@ defmodule Bypass do
   def expect(%Bypass{pid: pid}, fun),
     do: Bypass.Instance.call(pid, {:expect, fun})
 
+  def expect(%Bypass{pid: pid}, n, fun),
+    do: Bypass.Instance.call(pid, {:expect, n, fun})
+
   @doc """
   Expects the passed function to be called at least once for the specified route (method and path).
 
@@ -189,6 +199,9 @@ defmodule Bypass do
   @spec expect(Bypass.t(), String.t(), String.t(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
   def expect(%Bypass{pid: pid}, method, path, fun),
     do: Bypass.Instance.call(pid, {:expect, method, path, fun})
+
+  def expect(%Bypass{pid: pid}, method, path, n, fun),
+    do: Bypass.Instance.call(pid, {{:exactly, n}, method, path, fun})
 
   @doc """
   Expects the passed function to be called exactly once regardless of the route.

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -117,21 +117,21 @@ defmodule Bypass.Instance do
          _from,
          %{expectations: expectations} = state
        )
-       when expect in [:stub, :expect, :expect_once] or
-              (is_tuple(expect) and elem(expect, 0) == :exactly and
-                 method in [
-                   "GET",
-                   "POST",
-                   "HEAD",
-                   "PUT",
-                   "PATCH",
-                   "DELETE",
-                   "OPTIONS",
-                   "CONNECT",
-                   :any
-                 ] and
-                 (is_binary(path) or path == :any) and
-                 is_function(fun, 1)) do
+       when (expect in [:stub, :expect, :expect_once] or
+               (is_tuple(expect) and elem(expect, 0) == :exactly)) and
+              method in [
+                "GET",
+                "POST",
+                "HEAD",
+                "PUT",
+                "PATCH",
+                "DELETE",
+                "OPTIONS",
+                "CONNECT",
+                :any
+              ] and
+              (is_binary(path) or path == :any) and
+              is_function(fun, 1) do
     route = {method, path}
 
     updated_expectations =


### PR DESCRIPTION
Hi there!

Sometimes I want to set an expectation that my app will call particular endpoint an exact number of times.. I figured I can achieve that by setting some counter and increment it on each request, then assert on its value.. though, I think it would be nice to be able to set that expectation via `Bypass.expect` functions.. something similar to [`Mox.expect/4`](https://hexdocs.pm/mox/Mox.html#expect/4)

So in this change I attempted to do exactly that:
```elixir
Bypass.expect(bypass, 3, fn conn ->
  # ...
  # Plug.Conn.send_resp(conn, 200, "")
end)
```
and
```elixir
Bypass.expect(bypass, "GET", "/foo", 3, fn conn ->
  # ...
  # Plug.Conn.send_resp(conn, 200, "")
end)
```
And if that number of requests is not met - it will raise an error:
```
     Expected 3 HTTP request for Bypass at GET /foo, got 5
     stacktrace:
       (bypass 2.1.0) lib/bypass.ex:122: Bypass.do_verify_expectations/2
       ...
```
