### PR TITLE
Relax Ranch version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Bypass.Mixfile do
     [
       {:plug_cowboy, "~> 2.0"},
       {:plug, "~> 1.7"},
-      {:ranch, "~> 1.7.1"},
+      {:ranch, "~> 1.7"},
       {:ex_doc, "> 0.0.0", only: :dev},
       {:espec, "~> 1.6", only: [:dev, :test]},
       {:mint, "~> 1.1", only: :test},


### PR DESCRIPTION
Depending on 1.7.x prevents upgrading beyond Cowboy 2.8.0, since Ranch 1.8.0 is used by Cowboy 2.9.0 and up.