### PR TITLE
Allow IP address to be given per instance

### DIFF
--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -5,7 +5,7 @@ defmodule Bypass do
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
 
-  defstruct pid: nil, port: nil
+  defstruct pid: nil, port: nil, ip: nil
 
   @typedoc """
   Represents a Bypass server process.
@@ -25,6 +25,7 @@ defmodule Bypass do
   ## Options
 
   - `port` - Optional TCP port to listen to requests.
+  - `ip` - Optional TCP IP to listen to requests. Default is `{127, 0, 0, 1}`
 
   ## Examples
 
@@ -43,8 +44,9 @@ defmodule Bypass do
   def open(opts \\ []) do
     pid = start_instance(opts)
     port = Bypass.Instance.call(pid, :port)
+    ip = Bypass.Instance.call(pid, :ip)
     debug_log("Did open connection #{inspect(pid)} on port #{inspect(port)}")
-    bypass = %Bypass{pid: pid, port: port}
+    bypass = %Bypass{pid: pid, port: port, ip: ip}
     setup_framework_integration(test_framework(), bypass)
     bypass
   end

--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -25,16 +25,20 @@ defmodule Bypass.Instance do
 
   def init([opts]) do
     # Get a free port from the OS
-    case :ranch_tcp.listen(so_reuseport() ++ [ip: listen_ip(), port: Keyword.get(opts, :port, 0)]) do
+    case :ranch_tcp.listen(
+           so_reuseport() ++
+             [ip: Keyword.get(opts, :ip, listen_ip()), port: Keyword.get(opts, :port, 0)]
+         ) do
       {:ok, socket} ->
-        {:ok, port} = :inet.port(socket)
+        {:ok, {ip, port}} = :inet.sockname(socket)
         :erlang.port_close(socket)
 
         ref = make_ref()
-        socket = do_up(port, ref)
+        socket = do_up(ip, port, ref)
 
         state = %{
           expectations: %{},
+          ip: ip,
           port: port,
           ref: ref,
           socket: socket,
@@ -76,8 +80,12 @@ defmodule Bypass.Instance do
     {:reply, port, state}
   end
 
-  defp do_handle_call(:up, _from, %{port: port, ref: ref, socket: nil} = state) do
-    socket = do_up(port, ref)
+  defp do_handle_call(:ip, _, %{ip: ip} = state) do
+    {:reply, ip, state}
+  end
+
+  defp do_handle_call(:up, _from, %{ip: ip, port: port, ref: ref, socket: nil} = state) do
+    socket = do_up(ip, port, ref)
     {:reply, :ok, %{state | socket: socket}}
   end
 
@@ -317,9 +325,9 @@ defmodule Bypass.Instance do
 
   defp match_route(_, _), do: {false, nil}
 
-  defp do_up(port, ref) do
+  defp do_up(ip, port, ref) do
     plug_opts = [bypass_instance: self()]
-    {:ok, socket} = :ranch_tcp.listen(so_reuseport() ++ [ip: listen_ip(), port: port])
+    {:ok, socket} = :ranch_tcp.listen(so_reuseport() ++ [ip: ip, port: port])
     cowboy_opts = cowboy_opts(port, ref, socket)
     {:ok, _pid} = Plug.Cowboy.http(Bypass.Plug, plug_opts, cowboy_opts)
     socket


### PR DESCRIPTION
This is an improvement of the current global listen_ip env config. This way one can use the full 127/8 localhost range for testing. Also see https://datatracker.ietf.org/doc/html/rfc6890#section-2.2.2