### PR TITLE
Allow the user to specify the expected number of calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![License](https://img.shields.io/hexpm/l/bypass.svg)](https://github.com/PSPDFKit-labs/bypass/blob/master/LICENSE)
 [![Last Updated](https://img.shields.io/github/last-commit/PSPDFKit-labs/bypass.svg)](https://github.com/PSPDFKit-labs/bypass/commits/master)
 
-
 `Bypass` provides a quick way to create a custom plug that can be put in place
 instead of an actual HTTP server to return prebaked responses to client
 requests. This is most useful in tests, when you want to create a mock HTTP
@@ -31,10 +30,14 @@ the same port again. Both functions block until the socket updates its state.
 
 You can take any of the following approaches:
 
-* `expect/2` or `expect_once/2` to install a generic function that all calls to
+* `expect/2`, `expect/3` or `expect_once/2` to install a generic function that all calls to
   bypass will use
-* `expect/4` and/or `expect_once/4` to install specific routes (method and path)
+* `expect/4`, `expect/5` and/or `expect_once/4` to install specific routes (method and path)
 * `stub/4` to install specific routes without expectations
+* `expect/2` and `expect/4` well set up a called *at least once* expectaton.
+* `expect_once/2` and `expect_once/4` setup a called *exactly once* expecation.
+* `expect/3` and `expect/5` setup a called *exactly n times* expectation.
+
 * a combination of the above, where the routes will be used first, and then the
   generic version will be used as default
 

--- a/lib/bypass.ex
+++ b/lib/bypass.ex
@@ -109,11 +109,8 @@ defmodule Bypass do
       :ok_call ->
         :ok
 
-      {:error, :too_many_requests, {:any, :any}} ->
-        raise error_module, "Expected only one HTTP request for Bypass"
-
-      {:error, :too_many_requests, {method, path}} ->
-        raise error_module, "Expected only one HTTP request for Bypass at #{method} #{path}"
+      {:error, :too_many_requests, route_tuple, expected_actual_tuple} ->
+        raise error_module, format_too_many_requests_message(route_tuple, expected_actual_tuple)
 
       {:error, :unexpected_request, {:any, :any}} ->
         raise error_module, "Bypass got an HTTP request but wasn't expecting one"
@@ -132,6 +129,23 @@ defmodule Bypass do
       {:exit, {class, reason, stacktrace}} ->
         :erlang.raise(class, reason, stacktrace)
     end
+  end
+
+  defp format_too_many_requests_message(route, {expected, actual}) do
+    expected_language =
+      case expected do
+        0 -> "no HTTP requests"
+        1 -> "only 1 HTTP request"
+        plural -> "#{plural} HTTP requests"
+      end
+
+    route_language =
+      case route do
+        {:any, :any} -> ""
+        {method, path} -> " at #{method} #{path}"
+      end
+
+    "Expected #{expected_language} for Bypass#{route_language}, but got #{actual}"
   end
 
   @doc """
@@ -173,6 +187,21 @@ defmodule Bypass do
     do: Bypass.Instance.call(pid, {:expect, fun})
 
   @doc """
+  Expects the passed function to be called an exact number of times, regardless of the route.
+
+  ```elixir
+  Bypass.expect(bypass, 2, fn conn ->
+    assert "/1.1/statuses/update.json" == conn.request_path
+    assert "POST" == conn.method
+    Plug.Conn.resp(conn, 429, ~s<{"errors": [{"code": 88, "message": "Rate limit exceeded"}]}>)
+  end)
+  ```
+  """
+  @spec expect(Bypass.t(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
+  def expect(%Bypass{pid: pid}, count, fun),
+    do: Bypass.Instance.call(pid, {count, fun})
+
+  @doc """
   Expects the passed function to be called at least once for the specified route (method and path).
 
   - `method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
@@ -189,6 +218,25 @@ defmodule Bypass do
   @spec expect(Bypass.t(), String.t(), String.t(), (Plug.Conn.t() -> Plug.Conn.t())) :: :ok
   def expect(%Bypass{pid: pid}, method, path, fun),
     do: Bypass.Instance.call(pid, {:expect, method, path, fun})
+
+  @doc """
+  Expects the passed function to be called an exact number of times for the specified route (method and path).
+
+  - `method` is one of `["GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS", "CONNECT"]`
+
+  - `path` is the endpoint.
+
+  ```elixir
+  Bypass.expect(bypass, "POST", "/1.1/statuses/update.json", 2, fn conn ->
+    Agent.get_and_update(AgentModule, fn step_no -> {step_no, step_no + 1} end)
+    Plug.Conn.resp(conn, 200, "")
+  end)
+  ```
+  """
+  @spec expect(Bypass.t(), String.t(), String.t(), integer(), (Plug.Conn.t() -> Plug.Conn.t())) ::
+          :ok
+  def expect(%Bypass{pid: pid}, method, path, count, fun),
+    do: Bypass.Instance.call(pid, {count, method, path, fun})
 
   @doc """
   Expects the passed function to be called exactly once regardless of the route.

--- a/lib/bypass/plug.ex
+++ b/lib/bypass/plug.ex
@@ -30,6 +30,10 @@ defmodule Bypass.Plug do
       {:error, error, route} ->
         put_result(pid, route, make_ref(), {:error, error, route})
         raise "route error"
+
+      {:error, error, route, counts} ->
+        put_result(pid, route, make_ref(), {:error, error, route, counts})
+        raise "route error"
     end
   end
 


### PR DESCRIPTION
Allows the user to specify the number of calls to expect.  Verify will fail if the number of actual calls is different than the number of expected calls.