### PR TITLE
Avoid interpreting path as route

### DIFF
--- a/lib/bypass/instance.ex
+++ b/lib/bypass/instance.ex
@@ -4,7 +4,7 @@ defmodule Bypass.Instance do
   use GenServer, restart: :transient
 
   import Bypass.Utils
-  import Plug.Router.Utils, only: [build_path_match: 1]
+  import Plug.Router.Utils, only: [build_path_match: 1, split: 1]
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, [opts])
@@ -297,7 +297,7 @@ defmodule Bypass.Instance do
   end
 
   defp route_info(method, path, %{expectations: expectations} = _state) do
-    segments = build_path_match(path) |> elem(1)
+    segments = path |> split
 
     route =
       expectations

--- a/test/bypass_test.exs
+++ b/test/bypass_test.exs
@@ -643,4 +643,15 @@ defmodule BypassTest do
       Bypass.open(:error)
     end
   end
+
+  test "path can contain colon" do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "POST", "/resources/:resource", fn conn ->
+      assert conn.params == %{ "resource" => ":resource" }
+      Plug.Conn.send_resp(conn, 200, "")
+    end)
+
+    assert {:ok, 200, ""} = request(bypass.port, "/resources/:resource")
+  end
 end


### PR DESCRIPTION
I was trying to upgrade Bypass in a project but ran into the issue reported in #122.

Bypass will currently interpret a path as a route by using `Plug.Router.Utils.build_path_match` to split it into path segments.

The simplest demonstration of that is by using `/resources/:resource` as both route pattern and path. The `resource` parameter is then supposed to be `:resource` but as both are interpreted as route, the parameter ends up being `{:resource, [], nil}`. This may not be a problem based on whether the expectation relies on this parameter.

However, another scenario is if your path contains multiple colons, e.g. `/resources/a:b:c`. With Bypass' current dependency on Plug 1.10.4, this fails with the following exception:

```elixir
     ** (Plug.Router.InvalidSpecError) :identifier in routes must be made of letters, numbers and underscores
         (plug 1.10.4) lib/plug/router/utils.ex:209: Plug.Router.Utils.binary_to_identifier/2
         (plug 1.10.4) lib/plug/router/utils.ex:166: Plug.Router.Utils.segment_match/3
         (plug 1.10.4) lib/plug/router/utils.ex:131: Plug.Router.Utils.build_path_match/4
         (bypass 2.1.0) lib/bypass/instance.ex:300: Bypass.Instance.route_info/3
         (bypass 2.1.0) lib/bypass/instance.ex:162: Bypass.Instance.do_handle_call/3
         (stdlib 6.2) gen_server.erl:2381: :gen_server.try_handle_call/4
         (stdlib 6.2) gen_server.erl:2410: :gen_server.handle_msg/6
         (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
     Last message (from #PID<0.10094.0>): {:get_route, "POST", "/resources/a:b:c"}
```

Upgrading Plug to its latest release, version 1.16.1, changes the error but still fails:

```elixir
     ** (Plug.Router.InvalidSpecError) only one dynamic entry (:var or *glob) per path segment is allowed, got: "a:b:c"
         (plug 1.16.1) lib/plug/router/utils.ex:236: Plug.Router.Utils.build_path_clause/7
         (plug 1.16.1) lib/plug/router/utils.ex:142: Plug.Router.Utils.build_path_clause/3
         (plug 1.16.1) lib/plug/router/utils.ex:84: Plug.Router.Utils.build_path_match/2
         (bypass 2.1.0) lib/bypass/instance.ex:300: Bypass.Instance.route_info/3
         (bypass 2.1.0) lib/bypass/instance.ex:162: Bypass.Instance.do_handle_call/3
         (stdlib 6.2) gen_server.erl:2381: :gen_server.try_handle_call/4
         (stdlib 6.2) gen_server.erl:2410: :gen_server.handle_msg/6
         (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
     Last message (from #PID<0.903.0>): {:get_route, "POST", "/resources/a:b:c"}
```

Switching the implementation to use `Plug.Router.Utils.split` resolves the issue.